### PR TITLE
refactor: Use log crate for output instead of println

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,65 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +77,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "errno"
@@ -31,6 +125,54 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -46,6 +188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,10 +206,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -91,6 +275,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,8 +318,41 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -116,10 +368,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wayland-backend"
@@ -129,7 +420,7 @@ checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 0.38.44",
  "smallvec",
  "wayland-sys",
 ]
@@ -142,7 +433,7 @@ checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
 dependencies = [
  "bitflags",
  "log",
- "rustix",
+ "rustix 0.38.44",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -151,8 +442,24 @@ dependencies = [
 name = "wayland-kbd-osd"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "log",
+ "memmap2",
+ "tempfile",
  "wayland-client",
+ "wayland-protocols",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
 ]
 
 [[package]]
@@ -320,3 +627,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "wayland-kbd-osd"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 log = { version = "0.4.27", features = ["std"] }
 wayland-client = { version = "0.31.10", features = ["log"] }
+wayland-protocols = { version = "0.31.2", features = ["client", "unstable"] }
+tempfile = "3.10.1"
+memmap2 = "0.9.4"
+env_logger = "0.11.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,308 @@
+use wayland_client::{Connection, Dispatch, QueueHandle, Proxy};
+use wayland_client::protocol::{wl_compositor, wl_shm, wl_shm_pool, wl_surface, wl_buffer, wl_registry}; // wl_buffer is already here
+use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+
+// Remove unused File and Write
+use std::os::unix::io::{AsRawFd, BorrowedFd}; // Added BorrowedFd
+use memmap2::MmapMut;
+
+const WINDOW_WIDTH: i32 = 320;
+const WINDOW_HEIGHT: i32 = 240;
+
+struct AppState {
+    compositor: Option<wl_compositor::WlCompositor>,
+    shm: Option<wl_shm::WlShm>,
+    xdg_wm_base: Option<xdg_wm_base::XdgWmBase>,
+    surface: Option<wl_surface::WlSurface>,
+    buffer: Option<wl_buffer::WlBuffer>,
+    mmap: Option<MmapMut>,
+    configured_width: i32,
+    configured_height: i32,
+}
+
+impl AppState {
+    fn new() -> Self {
+        AppState {
+            compositor: None,
+            shm: None,
+            xdg_wm_base: None,
+            surface: None,
+            buffer: None,
+            mmap: None,
+            configured_width: WINDOW_WIDTH, // Default
+            configured_height: WINDOW_HEIGHT, // Default
+        }
+    }
+
+    fn draw(&mut self, qh: &QueueHandle<AppState>) {
+        if self.surface.is_none() || self.shm.is_none() || self.compositor.is_none() {
+            log::error!("Cannot draw: missing essential Wayland objects.");
+            return;
+        }
+
+        let surface = self.surface.as_ref().unwrap();
+        let shm = self.shm.as_ref().unwrap();
+
+        let width = self.configured_width;
+        let height = self.configured_height;
+        let stride = width * 4; // 4 bytes per pixel (ARGB8888)
+        let size = stride * height;
+
+        // Create a temporary file for shared memory
+        let temp_file = tempfile::tempfile().expect("Failed to create temp file"); // Removed mut
+        temp_file.set_len(size as u64).expect("Failed to set temp file length");
+
+        let fd = temp_file.as_raw_fd(); // Get raw fd first
+        let pool = unsafe { shm.create_pool(BorrowedFd::borrow_raw(fd), size, qh, ()) }; // Use BorrowedFd, needs unsafe for borrow_raw
+
+        let buffer = pool.create_buffer(0, width, height, stride, wl_shm::Format::Argb8888, qh, ());
+        pool.destroy(); // Pool can be destroyed after buffer creation
+
+        // Memory map the file
+        let mut mmap = unsafe { MmapMut::map_mut(&temp_file).expect("Failed to map temp file") };
+
+        // Draw a blue rectangle with a red border
+        for y in 0..height {
+            for x in 0..width {
+                let offset = (y * stride + x * 4) as usize;
+                let color: u32 = if x < 5 || x >= width - 5 || y < 5 || y >= height - 5 {
+                    0xFFFF0000 // Red border (ARGB)
+                } else {
+                    0xFF0000FF // Blue rectangle (ARGB)
+                };
+                mmap[offset..offset+4].copy_from_slice(&color.to_le_bytes());
+            }
+        }
+
+        // For "hello world", we'll just print to console for now, as rendering text is complex.
+        log::info!("Drawing content (rectangle + 'Hello World' placeholder)");
+
+        // Attach the buffer and commit
+        surface.attach(Some(&buffer), 0, 0);
+        surface.damage_buffer(0, 0, width, height); // Mark the whole buffer as damaged
+        surface.commit();
+
+        // Store buffer and mmap so they are not dropped immediately
+        // In a real app, you'd manage buffers more carefully (e.g., double buffering)
+        self.buffer = Some(buffer);
+        self.mmap = Some(mmap); // Keep mmap alive
+    }
+}
+
+
+impl Dispatch<xdg_wm_base::XdgWmBase, ()> for AppState {
+    fn event(
+        _state: &mut AppState,
+        proxy: &xdg_wm_base::XdgWmBase,
+        event: xdg_wm_base::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        if let xdg_wm_base::Event::Ping { serial } = event {
+            proxy.pong(serial);
+        }
+    }
+}
+
+impl Dispatch<xdg_surface::XdgSurface, ()> for AppState {
+    fn event(
+        state: &mut AppState,
+        surface_proxy: &xdg_surface::XdgSurface,
+        event: xdg_surface::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<AppState>,
+    ) {
+        if let xdg_surface::Event::Configure { serial, .. } = event {
+            surface_proxy.ack_configure(serial);
+            // Dimensions are now expected to be set by xdg_toplevel configure.
+            // This configure event is the trigger to draw with the new state.
+            if state.surface.is_some() {
+                 state.draw(qh); // draw will use state.configured_width/height
+            }
+        }
+    }
+}
+
+impl Dispatch<xdg_toplevel::XdgToplevel, ()> for AppState {
+    fn event(
+        state: &mut AppState,
+        _proxy: &xdg_toplevel::XdgToplevel,
+        event: xdg_toplevel::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        match event {
+            xdg_toplevel::Event::Configure { width, height, states } => {
+                log::debug!("XDG Toplevel Configure: width: {}, height: {}, states: {:?}", width, height, states);
+                // Use provided dimensions if > 0, otherwise keep existing (or default if first configure)
+                if width > 0 { state.configured_width = width; }
+                if height > 0 { state.configured_height = height; }
+                // Note: A more robust handling might involve checking if the surface is maximized, etc.
+                // and then deciding whether to use suggested size or a client-preferred one.
+            }
+            xdg_toplevel::Event::Close => {
+                // Handle window close
+                log::info!("XDG Toplevel Close event received. Application should exit.");
+                // TODO: Implement graceful exit for the application loop.
+            }
+            _ => { /* log::trace!("Unhandled xdg_toplevel event: {:?}", event); */ }
+        }
+    }
+}
+
+// Corrected Dispatch signatures for wl_compositor, wl_surface, wl_shm
+impl Dispatch<wl_compositor::WlCompositor, ()> for AppState {
+    fn event(
+        _state: &mut AppState,
+        _proxy: &wl_compositor::WlCompositor,
+        _event: wl_compositor::Event,
+        _udata: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        // No compositor events are usually handled by clients
+    }
+}
+
+impl Dispatch<wl_surface::WlSurface, ()> for AppState {
+    fn event(
+        _state: &mut AppState,
+        _proxy: &wl_surface::WlSurface,
+        _event: wl_surface::Event,
+        _udata: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        // Surface events (like enter, leave) can be handled here if needed
+    }
+}
+
+impl Dispatch<wl_shm::WlShm, ()> for AppState {
+    fn event(
+        _state: &mut AppState,
+        _proxy: &wl_shm::WlShm,
+        _event: wl_shm::Event,
+        _udata: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        // WL_SHM events (like format) can be handled here
+    }
+}
+
+// Required Dispatch implementations based on compiler errors
+impl Dispatch<wl_registry::WlRegistry, ()> for AppState {
+    fn event(
+        state: &mut AppState,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _udata: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<AppState>,
+    ) {
+        if let wl_registry::Event::Global { name, interface, version } = event {
+            match interface.as_str() {
+                "wl_compositor" => {
+                    let capped_version = std::cmp::min(version, 5); // Cap version for safety
+                    state.compositor = Some(registry.bind::<wl_compositor::WlCompositor, (), AppState>(name, capped_version, qh, ()));
+                }
+                "wl_shm" => {
+                    let capped_version = std::cmp::min(version, 1);
+                    state.shm = Some(registry.bind::<wl_shm::WlShm, (), AppState>(name, capped_version, qh, ()));
+                }
+                "xdg_wm_base" => {
+                    let capped_version = std::cmp::min(version, 3);
+                    let wm_base = registry.bind::<xdg_wm_base::XdgWmBase, (), AppState>(name, capped_version, qh, ());
+                    // Ping handling is done by AppState's Dispatch impl for XdgWmBase
+                    state.xdg_wm_base = Some(wm_base);
+                }
+                _ => { /* println!("Ignoring global: {} v{}", interface, version); */ }
+            }
+        } else if let wl_registry::Event::GlobalRemove { name } = event {
+            // This 'name' is the numeric ID of the global. Proper removal requires mapping this ID
+            // back to the objects stored in AppState, which can be complex.
+            log::info!("Global removed: ID {}", name);
+            // TODO: Implement logic to unbind or mark as None if a managed global is removed.
+        }
+    }
+}
+
+impl Dispatch<wl_shm_pool::WlShmPool, ()> for AppState {
+    fn event(
+        _state: &mut AppState,
+        _proxy: &wl_shm_pool::WlShmPool,
+        _event: wl_shm_pool::Event,
+        _udata: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        // No events from wl_shm_pool are expected by clients normally
+    }
+}
+
+impl Dispatch<wl_buffer::WlBuffer, ()> for AppState {
+    fn event(
+        _state: &mut AppState,
+        buffer: &wl_buffer::WlBuffer,
+        event: wl_buffer::Event,
+        _udata: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<AppState>,
+    ) {
+        if let wl_buffer::Event::Release = event {
+            log::debug!("Buffer {:?} released", buffer.id());
+            // In a real app, you would mark this buffer as free or destroy it.
+            // If this buffer is state.buffer, we might want to clear it:
+            // if state.buffer.as_ref().map_or(false, |b| b == buffer) {
+            //     state.buffer = None;
+            //     state.mmap = None; // And drop the mmap
+            // }
+        }
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
+    env_logger::init();
+    log::info!("Starting Wayland application...");
+
+    let conn = Connection::connect_to_env().unwrap();
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+
+    let mut app_state = AppState::new();
+
+    let display = conn.display();
+    // Request the registry. Events (globals) will be dispatched to AppState via its
+    // Dispatch<wl_registry::WlRegistry, ()> implementation.
+    let _registry = display.get_registry(&qh, ());
+
+    // First roundtrip to process globals and other initial events.
+    // The AppState's Dispatch<wl_registry::WlRegistry> will bind globals.
+    log::info!("Processing initial events for globals...");
+    event_queue.roundtrip(&mut app_state).unwrap();
+
+    // Check if essential globals were bound by the Dispatch implementation
+    if app_state.compositor.is_none() || app_state.shm.is_none() || app_state.xdg_wm_base.is_none() {
+        log::error!("Failed to bind essential Wayland globals. Compositor: {:?}, SHM: {:?}, XDG WM Base: {:?}", app_state.compositor.is_some(), app_state.shm.is_some(), app_state.xdg_wm_base.is_some());
+        panic!("Failed to bind essential Wayland globals. Check Dispatch<wl_registry::WlRegistry> logic and compositor logs.");
+    }
+    log::info!("Essential globals bound.");
+
+    let surface = app_state.compositor.as_ref().unwrap().create_surface(&qh, ());
+    app_state.surface = Some(surface.clone());
+
+    let xdg_surface = app_state.xdg_wm_base.as_ref().unwrap().get_xdg_surface(&surface, &qh, ());
+    let toplevel = xdg_surface.get_toplevel(&qh, ());
+    toplevel.set_title("Hello Wayland Rectangle".to_string());
+
+    surface.commit(); // Make the surface known.
+
+    log::info!("Wayland window configured. Waiting for events (like configure to draw)...");
+
+    loop {
+        event_queue.blocking_dispatch(&mut app_state).unwrap();
+    }
 }


### PR DESCRIPTION
- Replaced all `println!` and `eprintln!` calls with `log` macros (info, debug, error).
- Added `env_logger` dependency and initialized it in main.
- This provides more structured and configurable logging.