### PR TITLE
Add support for LCtrl/LAlt OSD state via libinput


### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "input"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+dependencies = [
+ "bitflags 2.9.1",
+ "input-sys",
+ "libc",
+ "log",
+ "udev",
+]
+
+[[package]]
+name = "input-sys"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +494,16 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -853,6 +899,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +979,8 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "euclid",
+ "input",
+ "libc",
  "log",
  "memmap2",
  "raqote",
@@ -995,6 +1055,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1009,6 +1078,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1045,6 +1129,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1057,6 +1147,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1066,6 +1162,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1093,6 +1195,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1102,6 +1210,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1117,6 +1231,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1126,6 +1246,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ env_logger = "0.11.3"
 raqote = "0.8.5"
 rusttype = "0.9.3"
 euclid = "0.22.11" # For Angle
+input = "0.9.1"
+libc = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use wayland_client::{Connection, Dispatch, QueueHandle, Proxy};
 use wayland_client::protocol::{wl_compositor, wl_shm, wl_shm_pool, wl_surface, wl_buffer, wl_registry};
 use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+use input; // Added for libinput
 
 // Graphics and Font rendering
-use raqote::{SolidSource, PathBuilder, DrawOptions, StrokeStyle, Transform, Source}; // Removed DrawTarget
+use raqote::{SolidSource, PathBuilder, DrawOptions, StrokeStyle, Transform, Source};
 use rusttype::{Font, Scale, point, PositionedGlyph, OutlineBuilder};
-use euclid::Angle; // Import Angle
+use euclid::Angle;
 
 // Struct to hold key properties
 struct KeyDisplay {
@@ -28,7 +29,6 @@ fn draw_single_key(
     key: &KeyDisplay,
     font: &Font<'_>
 ) {
-    // Calculate text metrics first (needed for centering)
     let scale = Scale::uniform(key.text_size);
     let v_metrics = font.v_metrics(scale);
     let glyphs: Vec<PositionedGlyph<'_>> = font
@@ -42,15 +42,13 @@ fn draw_single_key(
         .next()
         .unwrap_or(0.0);
 
-    // Create a transform for this specific key
     let transform = Transform::translation(key.center_x, key.center_y)
         .then_rotate(Angle::radians(key.rotation_degrees.to_radians()))
         .then_translate(raqote::Vector::new(-key.width / 2.0, -key.height / 2.0));
 
     dt.set_transform(&transform);
 
-    // Draw rounded rectangle (background)
-    let mut pb = PathBuilder::new(); // Create a new path builder for each key's geometry
+    let mut pb = PathBuilder::new();
     pb.move_to(0.0 + key.corner_radius, 0.0);
     pb.line_to(key.width - key.corner_radius, 0.0);
     pb.quad_to(key.width, 0.0, key.width, key.corner_radius);
@@ -64,8 +62,6 @@ fn draw_single_key(
     let key_path = pb.finish();
 
     dt.fill(&key_path, &Source::Solid(key.background_color), &DrawOptions::default());
-
-    // Draw rounded rectangle (border)
     dt.stroke(
         &key_path,
         &Source::Solid(key.border_color),
@@ -76,14 +72,13 @@ fn draw_single_key(
         &DrawOptions::default(),
     );
 
-    // Draw text
     let text_x = (key.width - text_width_pixels) / 2.0;
     let text_y = (key.height - key.text_size) / 2.0 + v_metrics.ascent;
     let text_transform = transform.then_translate(raqote::Vector::new(text_x, text_y));
     dt.set_transform(&text_transform);
 
     for glyph_instance in glyphs {
-        let mut glyph_pb = PathBuilder::new(); // Create a new PathBuilder for each glyph
+        let mut glyph_pb = PathBuilder::new();
         if glyph_instance.unpositioned().build_outline(&mut PathBuilderSink(&mut glyph_pb)) {
             let glyph_path = glyph_pb.finish();
             if !glyph_path.ops.is_empty() {
@@ -91,16 +86,40 @@ fn draw_single_key(
             }
         }
     }
-    // The main draw loop will reset the transform once after all keys (or other elements) are drawn.
 }
 
+use std::os::unix::io::{AsRawFd, BorrowedFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::fs::OpenOptions;
+use std::path::Path;
+use libc::{O_RDWR, O_NONBLOCK};
 
-// Remove unused File and Write
-use std::os::unix::io::{AsRawFd, BorrowedFd};
 use memmap2::MmapMut;
 
 const WINDOW_WIDTH: i32 = 320;
 const WINDOW_HEIGHT: i32 = 240;
+
+struct MyLibinputInterface;
+
+impl input::LibinputInterface for MyLibinputInterface {
+    fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
+        log::debug!("Opening path: {:?}, flags: {}", path, flags);
+        OpenOptions::new()
+            .custom_flags(O_RDWR | O_NONBLOCK)
+            .read(true)
+            .write(true)
+            .open(path)
+            .map(|file| file.into())
+            .map_err(|e| {
+                log::error!("Failed to open path {:?}: {}", path, e);
+                e.raw_os_error().unwrap_or(libc::EIO)
+            })
+    }
+    fn close_restricted(&mut self, fd: OwnedFd) {
+        drop(fd);
+        log::debug!("Closed device via OwnedFd drop");
+    }
+}
 
 struct AppState {
     compositor: Option<wl_compositor::WlCompositor>,
@@ -111,6 +130,9 @@ struct AppState {
     mmap: Option<MmapMut>,
     configured_width: i32,
     configured_height: i32,
+    input_context: Option<input::Libinput>,
+    left_ctrl_pressed: bool,
+    left_alt_pressed: bool,
 }
 
 impl AppState {
@@ -122,8 +144,11 @@ impl AppState {
             surface: None,
             buffer: None,
             mmap: None,
-            configured_width: WINDOW_WIDTH, // Default
-            configured_height: WINDOW_HEIGHT, // Default
+            configured_width: WINDOW_WIDTH,
+            configured_height: WINDOW_HEIGHT,
+            input_context: None,
+            left_ctrl_pressed: false,
+            left_alt_pressed: false,
         }
     }
 
@@ -138,7 +163,7 @@ impl AppState {
 
         let width = self.configured_width;
         let height = self.configured_height;
-        let stride = width * 4; // 4 bytes per pixel (ARGB8888)
+        let stride = width * 4;
         let size = stride * height;
 
         let temp_file = tempfile::tempfile().expect("Failed to create temp file");
@@ -152,53 +177,40 @@ impl AppState {
         let mut mmap = unsafe { MmapMut::map_mut(&temp_file).expect("Failed to map temp file") };
         let mut dt = raqote::DrawTarget::new(width, height);
 
-        // Clear the drawing target once
         dt.clear(SolidSource::from_unpremultiplied_argb(0x00, 0x00, 0x00, 0x00));
 
-        // Load font once
         let font_data = include_bytes!("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf");
         let font = Font::try_from_bytes(font_data as &[u8]).expect("Error constructing Font");
 
-        // Define common properties for keys, can be customized per key
-        let key_w: f32 = 80.0; // Slightly smaller keys to fit more
+        let key_w: f32 = 80.0;
         let key_h: f32 = 40.0;
         let corner_r: f32 = 8.0;
         let border_t: f32 = 2.0;
-        let default_rot: f32 = 30.0; // Less rotation to manage space
-        let txt_size: f32 = 18.0; // Smaller text
+        let default_rot: f32 = 30.0;
+        let txt_size: f32 = 18.0;
 
-        let border_c = SolidSource::from_unpremultiplied_argb(0xFF, 0x80, 0x80, 0x80); // Grey
-        let background_c = SolidSource::from_unpremultiplied_argb(0xFF, 0xE0, 0xE0, 0xE0); // Lighter grey
-        let text_c = SolidSource::from_unpremultiplied_argb(0xFF, 0x10, 0x10, 0x10); // Darker Black
+        let border_c = SolidSource::from_unpremultiplied_argb(0xFF, 0x80, 0x80, 0x80);
+        let background_c_default = SolidSource::from_unpremultiplied_argb(0xFF, 0xE0, 0xE0, 0xE0);
+        let background_c_pressed = SolidSource::from_unpremultiplied_argb(0xFF, 0xA0, 0xA0, 0xF0);
+        let text_c = SolidSource::from_unpremultiplied_argb(0xFF, 0x10, 0x10, 0x10);
+
+        let alt_bg = if self.left_alt_pressed { background_c_pressed } else { background_c_default };
+        let ctrl_bg = if self.left_ctrl_pressed { background_c_pressed } else { background_c_default };
 
         let keys_to_draw = vec![
             KeyDisplay {
                 text: "Alt".to_string(),
-                center_x: width as f32 * 0.70,
-                center_y: height as f32 * 0.60,
-                width: key_w,
-                height: key_h,
-                corner_radius: corner_r,
-                border_thickness: border_t,
-                rotation_degrees: default_rot,
-                text_size: txt_size,
-                border_color: border_c,
-                background_color: background_c,
-                text_color: text_c,
+                center_x: width as f32 * 0.70, center_y: height as f32 * 0.60,
+                width: key_w, height: key_h, corner_radius: corner_r, border_thickness: border_t,
+                rotation_degrees: default_rot, text_size: txt_size,
+                border_color: border_c, background_color: alt_bg, text_color: text_c,
             },
             KeyDisplay {
                 text: "Ctrl".to_string(),
-                center_x: width as f32 * 0.30,
-                center_y: height as f32 * 0.40,
-                width: key_w,
-                height: key_h,
-                corner_radius: corner_r,
-                border_thickness: border_t,
-                rotation_degrees: default_rot - 5.0, // Slightly different rotation
-                text_size: txt_size,
-                border_color: border_c,
-                background_color: background_c,
-                text_color: text_c,
+                center_x: width as f32 * 0.30, center_y: height as f32 * 0.40,
+                width: key_w, height: key_h, corner_radius: corner_r, border_thickness: border_t,
+                rotation_degrees: default_rot - 5.0, text_size: txt_size,
+                border_color: border_c, background_color: ctrl_bg, text_color: text_c,
             },
         ];
 
@@ -206,7 +218,6 @@ impl AppState {
             draw_single_key(&mut dt, &key_spec, &font);
         }
 
-        // Reset transform after all drawing operations on dt that use transforms
         dt.set_transform(&Transform::identity());
 
         let dt_buffer = dt.get_data_u8();
@@ -215,22 +226,17 @@ impl AppState {
                 let dt_buf_idx = (y_idx * width + x_idx) as usize * 4;
                 let mmap_buf_idx = (y_idx * stride + x_idx * 4) as usize;
                 if dt_buf_idx + 3 < dt_buffer.len() && mmap_buf_idx + 3 < mmap.len() {
-                    let a = dt_buffer[dt_buf_idx + 3]; // Raqote is BGRA in get_data_u8, so A is at +3
-                    let r = dt_buffer[dt_buf_idx + 2]; // R is at +2
-                    let g = dt_buffer[dt_buf_idx + 1]; // G is at +1
-                    let b = dt_buffer[dt_buf_idx + 0]; // B is at +0
-                    // Wayland expects ARGB8888, which means u32 with A in MSB.
-                    // On little-endian, memory layout for 0xAARRGGBB u32 is BB GG RR AA.
-                    // Raqote provides BGRA bytes: B, G, R, A.
-                    // So, we want to write [B, G, R, A] into mmap.
-                    // pixel_value from these bytes should be (A<<24)|(R<<16)|(G<<8)|B
+                    let a = dt_buffer[dt_buf_idx + 3];
+                    let r = dt_buffer[dt_buf_idx + 2];
+                    let g = dt_buffer[dt_buf_idx + 1];
+                    let b = dt_buffer[dt_buf_idx + 0];
                     let pixel_value = (a as u32) << 24 | (r as u32) << 16 | (g as u32) << 8 | (b as u32);
                     mmap[mmap_buf_idx..mmap_buf_idx+4].copy_from_slice(&pixel_value.to_le_bytes());
                 }
             }
         }
 
-        log::info!("Drawing content (rotated 'Alt' key)");
+        log::info!("Drawing content");
         surface.attach(Some(&buffer), 0, 0);
         surface.damage_buffer(0, 0, width, height);
         surface.commit();
@@ -239,199 +245,82 @@ impl AppState {
     }
 }
 
-// Helper for rusttype to raqote path conversion
 struct PathBuilderSink<'a>(&'a mut raqote::PathBuilder);
 
-impl<'a> OutlineBuilder for PathBuilderSink<'a> { // Ensure this uses rusttype::OutlineBuilder
-    fn move_to(&mut self, x: f32, y: f32) {
-        self.0.move_to(x, y);
-    }
-    fn line_to(&mut self, x: f32, y: f32) {
-        self.0.line_to(x, y);
-    }
-    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) {
-        self.0.quad_to(x1, y1, x, y);
-    }
-    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) {
-        self.0.cubic_to(x1, y1, x2, y2, x, y);
-    }
-    fn close(&mut self) {
-        self.0.close();
-    }
+impl<'a> OutlineBuilder for PathBuilderSink<'a> {
+    fn move_to(&mut self, x: f32, y: f32) { self.0.move_to(x, y); }
+    fn line_to(&mut self, x: f32, y: f32) { self.0.line_to(x, y); }
+    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) { self.0.quad_to(x1, y1, x, y); }
+    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) { self.0.cubic_to(x1, y1, x2, y2, x, y); }
+    fn close(&mut self) { self.0.close(); }
 }
 
-
 impl Dispatch<xdg_wm_base::XdgWmBase, ()> for AppState {
-    fn event(
-        _state: &mut AppState,
-        proxy: &xdg_wm_base::XdgWmBase,
-        event: xdg_wm_base::Event,
-        _data: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
-        if let xdg_wm_base::Event::Ping { serial } = event {
-            proxy.pong(serial);
-        }
+    fn event( _state: &mut AppState, proxy: &xdg_wm_base::XdgWmBase, event: xdg_wm_base::Event, _data: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {
+        if let xdg_wm_base::Event::Ping { serial } = event { proxy.pong(serial); }
     }
 }
 
 impl Dispatch<xdg_surface::XdgSurface, ()> for AppState {
-    fn event(
-        state: &mut AppState,
-        surface_proxy: &xdg_surface::XdgSurface,
-        event: xdg_surface::Event,
-        _data: &(),
-        _conn: &Connection,
-        qh: &QueueHandle<AppState>,
-    ) {
+    fn event( state: &mut AppState, surface_proxy: &xdg_surface::XdgSurface, event: xdg_surface::Event, _data: &(), _conn: &Connection, qh: &QueueHandle<AppState>) {
         if let xdg_surface::Event::Configure { serial, .. } = event {
             surface_proxy.ack_configure(serial);
-            // Dimensions are now expected to be set by xdg_toplevel configure.
-            // This configure event is the trigger to draw with the new state.
-            if state.surface.is_some() {
-                 state.draw(qh); // draw will use state.configured_width/height
-            }
+            if state.surface.is_some() { state.draw(qh); }
         }
     }
 }
 
 impl Dispatch<xdg_toplevel::XdgToplevel, ()> for AppState {
-    fn event(
-        state: &mut AppState,
-        _proxy: &xdg_toplevel::XdgToplevel,
-        event: xdg_toplevel::Event,
-        _data: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
+    fn event( state: &mut AppState, _proxy: &xdg_toplevel::XdgToplevel, event: xdg_toplevel::Event, _data: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {
         match event {
             xdg_toplevel::Event::Configure { width, height, states } => {
                 log::debug!("XDG Toplevel Configure: width: {}, height: {}, states: {:?}", width, height, states);
-                // Use provided dimensions if > 0, otherwise keep existing (or default if first configure)
                 if width > 0 { state.configured_width = width; }
                 if height > 0 { state.configured_height = height; }
-                // Note: A more robust handling might involve checking if the surface is maximized, etc.
-                // and then deciding whether to use suggested size or a client-preferred one.
             }
             xdg_toplevel::Event::Close => {
-                // Handle window close
                 log::info!("XDG Toplevel Close event received. Application should exit.");
-                // TODO: Implement graceful exit for the application loop.
+                // TODO: Graceful exit
             }
-            _ => { /* log::trace!("Unhandled xdg_toplevel event: {:?}", event); */ }
+            _ => {}
         }
     }
 }
 
-// Corrected Dispatch signatures for wl_compositor, wl_surface, wl_shm
 impl Dispatch<wl_compositor::WlCompositor, ()> for AppState {
-    fn event(
-        _state: &mut AppState,
-        _proxy: &wl_compositor::WlCompositor,
-        _event: wl_compositor::Event,
-        _udata: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
-        // No compositor events are usually handled by clients
-    }
+    fn event( _state: &mut AppState, _proxy: &wl_compositor::WlCompositor, _event: wl_compositor::Event, _udata: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {}
 }
 
 impl Dispatch<wl_surface::WlSurface, ()> for AppState {
-    fn event(
-        _state: &mut AppState,
-        _proxy: &wl_surface::WlSurface,
-        _event: wl_surface::Event,
-        _udata: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
-        // Surface events (like enter, leave) can be handled here if needed
-    }
+    fn event( _state: &mut AppState, _proxy: &wl_surface::WlSurface, _event: wl_surface::Event, _udata: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {}
 }
 
 impl Dispatch<wl_shm::WlShm, ()> for AppState {
-    fn event(
-        _state: &mut AppState,
-        _proxy: &wl_shm::WlShm,
-        _event: wl_shm::Event,
-        _udata: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
-        // WL_SHM events (like format) can be handled here
-    }
+    fn event( _state: &mut AppState, _proxy: &wl_shm::WlShm, _event: wl_shm::Event, _udata: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {}
 }
 
-// Required Dispatch implementations based on compiler errors
 impl Dispatch<wl_registry::WlRegistry, ()> for AppState {
-    fn event(
-        state: &mut AppState,
-        registry: &wl_registry::WlRegistry,
-        event: wl_registry::Event,
-        _udata: &(),
-        _conn: &Connection,
-        qh: &QueueHandle<AppState>,
-    ) {
+    fn event( state: &mut AppState, registry: &wl_registry::WlRegistry, event: wl_registry::Event, _udata: &(), _conn: &Connection, qh: &QueueHandle<AppState>) {
         if let wl_registry::Event::Global { name, interface, version } = event {
             match interface.as_str() {
-                "wl_compositor" => {
-                    let capped_version = std::cmp::min(version, 5); // Cap version for safety
-                    state.compositor = Some(registry.bind::<wl_compositor::WlCompositor, (), AppState>(name, capped_version, qh, ()));
-                }
-                "wl_shm" => {
-                    let capped_version = std::cmp::min(version, 1);
-                    state.shm = Some(registry.bind::<wl_shm::WlShm, (), AppState>(name, capped_version, qh, ()));
-                }
-                "xdg_wm_base" => {
-                    let capped_version = std::cmp::min(version, 3);
-                    let wm_base = registry.bind::<xdg_wm_base::XdgWmBase, (), AppState>(name, capped_version, qh, ());
-                    // Ping handling is done by AppState's Dispatch impl for XdgWmBase
-                    state.xdg_wm_base = Some(wm_base);
-                }
-                _ => { /* println!("Ignoring global: {} v{}", interface, version); */ }
+                "wl_compositor" => { state.compositor = Some(registry.bind::<wl_compositor::WlCompositor, (), AppState>(name, std::cmp::min(version,5), qh, ())); }
+                "wl_shm" => { state.shm = Some(registry.bind::<wl_shm::WlShm, (), AppState>(name, std::cmp::min(version,1), qh, ())); }
+                "xdg_wm_base" => { state.xdg_wm_base = Some(registry.bind::<xdg_wm_base::XdgWmBase, (), AppState>(name, std::cmp::min(version,3), qh, ())); }
+                _ => {}
             }
         } else if let wl_registry::Event::GlobalRemove { name } = event {
-            // This 'name' is the numeric ID of the global. Proper removal requires mapping this ID
-            // back to the objects stored in AppState, which can be complex.
             log::info!("Global removed: ID {}", name);
-            // TODO: Implement logic to unbind or mark as None if a managed global is removed.
         }
     }
 }
 
 impl Dispatch<wl_shm_pool::WlShmPool, ()> for AppState {
-    fn event(
-        _state: &mut AppState,
-        _proxy: &wl_shm_pool::WlShmPool,
-        _event: wl_shm_pool::Event,
-        _udata: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
-        // No events from wl_shm_pool are expected by clients normally
-    }
+    fn event( _state: &mut AppState, _proxy: &wl_shm_pool::WlShmPool, _event: wl_shm_pool::Event, _udata: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {}
 }
 
 impl Dispatch<wl_buffer::WlBuffer, ()> for AppState {
-    fn event(
-        _state: &mut AppState,
-        buffer: &wl_buffer::WlBuffer,
-        event: wl_buffer::Event,
-        _udata: &(),
-        _conn: &Connection,
-        _qh: &QueueHandle<AppState>,
-    ) {
-        if let wl_buffer::Event::Release = event {
-            log::debug!("Buffer {:?} released", buffer.id());
-            // In a real app, you would mark this buffer as free or destroy it.
-            // If this buffer is state.buffer, we might want to clear it:
-            // if state.buffer.as_ref().map_or(false, |b| b == buffer) {
-            //     state.buffer = None;
-            //     state.mmap = None; // And drop the mmap
-            // }
-        }
+    fn event( _state: &mut AppState, buffer: &wl_buffer::WlBuffer, event: wl_buffer::Event, _udata: &(), _conn: &Connection, _qh: &QueueHandle<AppState>) {
+        if let wl_buffer::Event::Release = event { log::debug!("Buffer {:?} released", buffer.id()); }
     }
 }
 
@@ -442,38 +331,132 @@ fn main() {
     let conn = Connection::connect_to_env().unwrap();
     let mut event_queue = conn.new_event_queue();
     let qh = event_queue.handle();
-
     let mut app_state = AppState::new();
-
-    let display = conn.display();
-    // Request the registry. Events (globals) will be dispatched to AppState via its
-    // Dispatch<wl_registry::WlRegistry, ()> implementation.
-    let _registry = display.get_registry(&qh, ());
-
-    // First roundtrip to process globals and other initial events.
-    // The AppState's Dispatch<wl_registry::WlRegistry> will bind globals.
-    log::info!("Processing initial events for globals...");
+    let _registry = conn.display().get_registry(&qh, ());
     event_queue.roundtrip(&mut app_state).unwrap();
 
-    // Check if essential globals were bound by the Dispatch implementation
     if app_state.compositor.is_none() || app_state.shm.is_none() || app_state.xdg_wm_base.is_none() {
-        log::error!("Failed to bind essential Wayland globals. Compositor: {:?}, SHM: {:?}, XDG WM Base: {:?}", app_state.compositor.is_some(), app_state.shm.is_some(), app_state.xdg_wm_base.is_some());
-        panic!("Failed to bind essential Wayland globals. Check Dispatch<wl_registry::WlRegistry> logic and compositor logs.");
+        panic!("Failed to bind essential Wayland globals.");
     }
     log::info!("Essential globals bound.");
 
+    let interface = MyLibinputInterface;
+    let mut libinput_context = input::Libinput::new_with_udev(interface);
+    match libinput_context.udev_assign_seat("seat0") {
+        Ok(_) => {
+            log::info!("Successfully assigned seat0 to libinput context.");
+            app_state.input_context = Some(libinput_context);
+        }
+        Err(e) => {
+            log::error!("Failed to assign seat0 to libinput context: {:?}", e);
+            log::error!("Input monitoring will be disabled. Ensure permissions for /dev/input devices.");
+        }
+    }
+
     let surface = app_state.compositor.as_ref().unwrap().create_surface(&qh, ());
     app_state.surface = Some(surface.clone());
-
     let xdg_surface = app_state.xdg_wm_base.as_ref().unwrap().get_xdg_surface(&surface, &qh, ());
     let toplevel = xdg_surface.get_toplevel(&qh, ());
-    toplevel.set_title("Hello Wayland Rectangle".to_string());
+    toplevel.set_title("Wayland Keyboard OSD".to_string());
+    surface.commit();
+    log::info!("Wayland window configured. Waiting for events...");
 
-    surface.commit(); // Make the surface known.
-
-    log::info!("Wayland window configured. Waiting for events (like configure to draw)...");
+    use input::event::Event as LibinputEvent;
+    use input::event::keyboard::{KeyboardEvent, KeyState, KeyboardEventTrait}; // KeyboardKeyEvent removed as it's the type of key_event
+    use std::time::Duration;
 
     loop {
-        event_queue.blocking_dispatch(&mut app_state).unwrap();
+        match event_queue.dispatch_pending(&mut app_state) {
+            Ok(_) => {}
+            Err(e) => {
+                log::error!("Error dispatching Wayland events: {}", e);
+                match e {
+                    wayland_client::DispatchError::Backend(err) => { // err is wayland_client::backend::WaylandError
+                        match err {
+                            wayland_client::backend::WaylandError::Io(io_err) => {
+                                if io_err.kind() == std::io::ErrorKind::Interrupted {
+                                    log::warn!("Wayland dispatch interrupted (IO), continuing.");
+                                    continue;
+                                }
+                                log::error!("Wayland dispatch IO error: {}, breaking loop.", io_err);
+                                break;
+                            }
+                            wayland_client::backend::WaylandError::Protocol(protocol_err) => {
+                                log::error!("Wayland dispatch protocol error: {}, breaking loop.", protocol_err);
+                                break;
+                            }
+                            // If dlopen feature is not active, Io and Protocol are exhaustive.
+                            // The NoWaylandLib variant is cfg'd out.
+                            // The previous _ arm caused an unreachable_patterns warning.
+                        }
+                    }
+                    _ => {
+                        log::error!("Unhandled Wayland dispatch error (not Backend): {}, breaking loop.", e);
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut needs_redraw = false;
+        if let Some(ref mut context) = app_state.input_context {
+            if context.dispatch().is_err() {
+                log::error!("Libinput dispatch error in event processing loop");
+            }
+            while let Some(event) = context.next() {
+                if let LibinputEvent::Keyboard(KeyboardEvent::Key(key_event)) = event { // key_event is KeyboardKeyEvent
+                    let key_code = key_event.key();
+                    let key_state = key_event.key_state();
+                    log::trace!("Key event: code {}, state {:?}", key_code, key_state);
+                    let mut changed = false;
+                    match key_code {
+                        29 => {
+                            let pressed = key_state == KeyState::Pressed;
+                            if app_state.left_ctrl_pressed != pressed {
+                                app_state.left_ctrl_pressed = pressed;
+                                changed = true;
+                                log::info!("Left Ctrl state changed: {}", pressed);
+                            }
+                        }
+                        56 => {
+                            let pressed = key_state == KeyState::Pressed;
+                            if app_state.left_alt_pressed != pressed {
+                                app_state.left_alt_pressed = pressed;
+                                changed = true;
+                                log::info!("Left Alt state changed: {}", pressed);
+                            }
+                        }
+                        _ => {}
+                    }
+                    if changed { needs_redraw = true; }
+                }
+            }
+        }
+
+        if needs_redraw {
+            if app_state.surface.is_some() && app_state.compositor.is_some() && app_state.shm.is_some() {
+                 app_state.draw(&qh);
+            } else {
+                log::warn!("Skipping draw due to uninitialized Wayland components.");
+            }
+        }
+
+        if let Err(e) = conn.flush() { // e is wayland_client::backend::WaylandError
+            log::error!("Failed to flush Wayland connection: {}", e);
+            match e {
+                wayland_client::backend::WaylandError::Io(io_err) => {
+                    if io_err.kind() != std::io::ErrorKind::WouldBlock {
+                        log::error!("Wayland flush IO error (not WouldBlock): {}, breaking loop.", io_err);
+                        break;
+                    }
+                    log::trace!("Wayland flush returned WouldBlock, continuing.");
+                }
+                _ => {
+                    log::error!("Critical Wayland flush error: {:?}, breaking loop.", e);
+                    break;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(16));
     }
 }


### PR DESCRIPTION

- Integrates libinput to monitor global keyboard events for Left Control
  and Left Alt modifier keys.
- Updates the Wayland OSD window to change the background color of the
  "Ctrl" and "Alt" key displays when the respective keys are pressed.
- Includes error handling for Wayland communication and libinput setup.
- Adds necessary dependencies (input crate for libinput bindings, libc)
  and system dependencies (libinput-dev, libudev-dev).