### PR TITLE
feat: Allow string and optional keycodes in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +836,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -1055,9 +1074,12 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
+ "once_cell",
  "raqote",
+ "regex",
  "rusttype",
  "serde",
+ "serde-value",
  "tempfile",
  "toml",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ input = "0.9.1"
 libc = "0.2"
 toml = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde-value = "0.7" # For flexible TOML value parsing
+regex = "1.10"      # For parsing input-event-codes.h
+once_cell = "1.19"  # For static LAZY KEYCODE_MAP

--- a/keys.toml
+++ b/keys.toml
@@ -1,15 +1,664 @@
+# Default 85% (Tenkeyless) Keyboard Layout
+# Coordinates are relative and will be scaled by the application.
+# Standard key size is assumed to be 50x50 units, with spacing of 5 units.
+# X coordinates increase to the right, Y coordinates increase downwards.
+
+# Function Row
+[[key]]
+name = "Esc"
+x = 0
+y = 0
+width = 50
+height = 50
+# keycode = "esc" # Test defaulting
+
+[[key]]
+name = "F1"
+x = 75
+y = 0
+width = 50
+height = 50
+# keycode = "f1"
+
+[[key]]
+name = "F2"
+x = 130
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F3"
+x = 185
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F4"
+x = 240
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F5"
+x = 320
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F6"
+x = 375
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F7"
+x = 430
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F8"
+x = 485
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F9"
+x = 565
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F10"
+x = 620
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F11"
+x = 675
+y = 0
+width = 50
+height = 50
+
+[[key]]
+name = "F12"
+x = 730
+y = 0
+width = 50
+height = 50
+# keycode = "f12"
+
+# Number Row
+[[key]]
+name = "`"
+x = 0
+y = 55
+width = 50
+height = 50
+keycode = "grave"
+
+[[key]]
+name = "1"
+x = 55
+y = 55
+width = 50
+height = 50
+# keycode = "1"
+
+[[key]]
+name = "2"
+x = 110
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "3"
+x = 165
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "4"
+x = 220
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "5"
+x = 275
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "6"
+x = 330
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "7"
+x = 385
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "8"
+x = 440
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "9"
+x = 495
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "0"
+x = 550
+y = 55
+width = 50
+height = 50
+
+[[key]]
+name = "-"
+x = 605
+y = 55
+width = 50
+height = 50
+keycode = "minus"
+
+[[key]]
+name = "="
+x = 660
+y = 55
+width = 50
+height = 50
+keycode = "equal"
+
+[[key]]
+name = "Backspace"
+x = 715
+y = 55
+width = 105 # Wider
+height = 50
+# keycode = "backspace"
+
+# Top Alpha Row (QWERTY)
+[[key]]
+name = "Tab"
+x = 0
+y = 110
+width = 80 # Wider
+height = 50
+# keycode = "tab"
+
 [[key]]
 name = "Q"
-width = 60
-height = 60
-x = 50
-y = 50
-keycode = 16
+x = 85
+y = 110
+width = 50
+height = 50
 
 [[key]]
 name = "W"
+x = 140
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "E"
+x = 195
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "R"
+x = 250
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "T"
+x = 305
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "Y"
+x = 360
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "U"
+x = 415
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "I"
+x = 470
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "O"
+x = 525
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "P"
+x = 580
+y = 110
+width = 50
+height = 50
+
+[[key]]
+name = "["
+x = 635
+y = 110
+width = 50
+height = 50
+keycode = "leftbrace"
+
+[[key]]
+name = "]"
+x = 690
+y = 110
+width = 50
+height = 50
+keycode = "rightbrace"
+
+[[key]]
+name = "\\"
+x = 745
+y = 110
+width = 70 # Often wider
+height = 50
+keycode = "backslash"
+
+# Middle Alpha Row (ASDF)
+[[key]]
+name = "Caps Lock"
+x = 0
+y = 165
+width = 95 # Wider
+height = 50
+keycode = "capslock"
+
+[[key]]
+name = "A"
+x = 100
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "S"
+x = 155
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "D"
+x = 210
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "F"
+x = 265
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "G"
+x = 320
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "H"
+x = 375
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "J"
+x = 430
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "K"
+x = 485
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = "L"
+x = 540
+y = 165
+width = 50
+height = 50
+
+[[key]]
+name = ";"
+x = 595
+y = 165
+width = 50
+height = 50
+keycode = "semicolon"
+
+[[key]]
+name = "'"
+x = 650
+y = 165
+width = 50
+height = 50
+keycode = "apostrophe"
+
+[[key]]
+name = "Enter"
+x = 705
+y = 165
+width = 110 # Wider
+height = 50
+# keycode = "enter"
+
+# Bottom Alpha Row (ZXCV)
+[[key]]
+name = "L. Shift"
+x = 0
+y = 220
+width = 120 # Wider
+height = 50
+keycode = "leftshift"
+
+[[key]]
+name = "Z"
+x = 125
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = "X"
+x = 180
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = "C"
+x = 235
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = "V"
+x = 290
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = "B"
+x = 345
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = "N"
+x = 400
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = "M"
+x = 455
+y = 220
+width = 50
+height = 50
+
+[[key]]
+name = ","
+x = 510
+y = 220
+width = 50
+height = 50
+keycode = "comma"
+
+[[key]]
+name = "."
+x = 565
+y = 220
+width = 50
+height = 50
+keycode = "dot"
+
+[[key]]
+name = "/"
+x = 620
+y = 220
+width = 50
+height = 50
+keycode = "slash"
+
+[[key]]
+name = "R. Shift"
+x = 675
+y = 220
+width = 140 # Wider
+height = 50
+keycode = "rightshift"
+
+# Bottom Row (Modifiers & Space)
+[[key]]
+name = "L. Ctrl"
+x = 0
+y = 275
+width = 70
+height = 50
+keycode = "leftctrl"
+
+[[key]]
+name = "L. Super" # Or L. Win
+x = 75
+y = 275
 width = 60
-height = 60
-x = 120
-y = 50
-keycode = 17
+height = 50
+keycode = "leftmeta"
+
+[[key]]
+name = "L. Alt"
+x = 140
+y = 275
+width = 70
+height = 50
+keycode = "leftalt"
+
+[[key]]
+name = "Space"
+x = 215
+y = 275
+width = 300 # Much Wider
+height = 50
+# keycode = "space"
+
+[[key]]
+name = "R. Alt" # Or AltGr
+x = 520
+y = 275
+width = 70
+height = 50
+keycode = "rightalt"
+
+[[key]]
+name = "R. Super" # Or R. Win
+x = 595
+y = 275
+width = 60
+height = 50
+keycode = "rightmeta"
+
+[[key]]
+name = "Menu"
+x = 660
+y = 275
+width = 60
+height = 50
+# keycode = "menu"
+
+[[key]]
+name = "R. Ctrl"
+x = 725
+y = 275
+width = 90
+height = 50
+keycode = "rightctrl"
+
+
+# Navigation Cluster
+[[key]]
+name = "PrtSc" # Print Screen / SysRq
+x = 840
+y = 0
+width = 50
+height = 50
+keycode = "sysrq" # Often maps to SYSRQ
+
+[[key]]
+name = "ScrollLk" # Scroll Lock
+x = 895
+y = 0
+width = 50
+height = 50
+keycode = "scrolllock"
+
+[[key]]
+name = "Pause" # Pause/Break
+x = 950
+y = 0
+width = 50
+height = 50
+# keycode = "pause"
+
+[[key]]
+name = "Ins" # Insert
+x = 840
+y = 55
+width = 50
+height = 50
+keycode = "insert"
+
+[[key]]
+name = "Home"
+x = 895
+y = 55
+width = 50
+height = 50
+# keycode = "home"
+
+[[key]]
+name = "PgUp" # Page Up
+x = 950
+y = 55
+width = 50
+height = 50
+keycode = "pageup"
+
+[[key]]
+name = "Del" # Delete
+x = 840
+y = 110
+width = 50
+height = 50
+keycode = "delete"
+
+[[key]]
+name = "End"
+x = 895
+y = 110
+width = 50
+height = 50
+# keycode = "end"
+
+[[key]]
+name = "PgDn" # Page Down
+x = 950
+y = 110
+width = 50
+height = 50
+keycode = "pagedown"
+
+# Arrow Keys
+[[key]]
+name = "Up"
+x = 895
+y = 220
+width = 50
+height = 50
+keycode = "up"
+
+[[key]]
+name = "Left"
+x = 840
+y = 275
+width = 50
+height = 50
+keycode = "left"
+
+[[key]]
+name = "Down"
+x = 895
+y = 275
+width = 50
+height = 50
+keycode = "down"
+
+[[key]]
+name = "Right"
+x = 950
+y = 275
+width = 50
+height = 50
+keycode = "right"

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -1,0 +1,457 @@
+// Based on Linux input-event-codes.h
+// Fetched from: https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/input-event-codes.h
+
+pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
+    let mut normalized_key_name = key_name_str.to_lowercase();
+
+    // Replace underscores globally
+    normalized_key_name = normalized_key_name.replace("_", "");
+
+    // Replace hyphens only if the string is likely an alias rather than a symbol key itself
+    // This is a heuristic: if it contains letters, it's more likely an alias.
+    // Single character symbols like '-' or '=' should not have their hyphen removed.
+    if normalized_key_name.chars().any(char::is_alphabetic) {
+        normalized_key_name = normalized_key_name.replace("-", "");
+    }
+
+    // Handle ambiguous keys first (using the already partially normalized name)
+    match normalized_key_name.as_str() {
+        "shift" => return Err("Ambiguous key name 'shift'. Please specify one of: leftshift, rightshift".to_string()),
+        "ctrl" | "control" => return Err("Ambiguous key name 'ctrl'/'control'. Please specify one of: leftctrl, rightctrl".to_string()),
+        "alt" => return Err("Ambiguous key name 'alt'. Please specify one of: leftalt, rightalt".to_string()),
+        "meta" | "win" | "windows" | "super" => return Err("Ambiguous key name 'meta'/'win'/'super'. Please specify one of: leftmeta, rightmeta (or lwin, rwin, etc.)".to_string()),
+        _ => {} // Not an ambiguous key, proceed to main match
+    }
+
+    match normalized_key_name.as_str() {
+        // Standard Keys from input-event-codes.h
+        "esc" | "escape" => Ok(1),
+        "1" => Ok(2),
+        "2" => Ok(3),
+        "3" => Ok(4),
+        "4" => Ok(5),
+        "5" => Ok(6),
+        "6" => Ok(7),
+        "7" => Ok(8),
+        "8" => Ok(9),
+        "9" => Ok(10),
+        "0" => Ok(11),
+        "minus" | "-" => Ok(12),
+        "equal" | "=" => Ok(13),
+        "backspace" | "bksp" => Ok(14),
+        "tab" => Ok(15),
+        "q" => Ok(16),
+        "w" => Ok(17),
+        "e" => Ok(18),
+        "r" => Ok(19),
+        "t" => Ok(20),
+        "y" => Ok(21),
+        "u" => Ok(22),
+        "i" => Ok(23),
+        "o" => Ok(24),
+        "p" => Ok(25),
+        "leftbrace" | "[" | "lbracket" => Ok(26),
+        "rightbrace" | "]" | "rbracket" => Ok(27),
+        "enter" | "return" => Ok(28), // KEY_ENTER
+        "leftctrl" | "lctrl" => Ok(29),
+        "a" => Ok(30),
+        "s" => Ok(31),
+        "d" => Ok(32),
+        "f" => Ok(33),
+        "g" => Ok(34),
+        "h" => Ok(35),
+        "j" => Ok(36),
+        "k" => Ok(37),
+        "l" => Ok(38),
+        "semicolon" | ";" => Ok(39),
+        "apostrophe" | "'" | "quote" => Ok(40),
+        "grave" | "`" | "tilde" => Ok(41),
+        "leftshift" | "lshift" => Ok(42),
+        "backslash" | "\\" => Ok(43),
+        "z" => Ok(44),
+        "x" => Ok(45),
+        "c" => Ok(46),
+        "v" => Ok(47),
+        "b" => Ok(48),
+        "n" => Ok(49),
+        "m" => Ok(50),
+        "comma" | "," => Ok(51),
+        "dot" | "." | "period" => Ok(52),
+        "slash" | "/" => Ok(53),
+        "rightshift" | "rshift" => Ok(54),
+        "kpasterisk" | "keypadasterisk" | "kpmultiply" | "kpmul" => Ok(55),
+        "leftalt" | "lalt" => Ok(56),
+        "space" => Ok(57),
+        "capslock" | "caps" => Ok(58),
+        "f1" => Ok(59),
+        "f2" => Ok(60),
+        "f3" => Ok(61),
+        "f4" => Ok(62),
+        "f5" => Ok(63),
+        "f6" => Ok(64),
+        "f7" => Ok(65),
+        "f8" => Ok(66),
+        "f9" => Ok(67),
+        "f10" => Ok(68),
+        "numlock" | "num" => Ok(69),
+        "scrolllock" | "scroll" => Ok(70),
+        "kp7" | "keypad7" => Ok(71),
+        "kp8" | "keypad8" => Ok(72),
+        "kp9" | "keypad9" => Ok(73),
+        "kpminus" | "keypadminus" | "kpsubtract" | "kpsub" => Ok(74),
+        "kp4" | "keypad4" => Ok(75),
+        "kp5" | "keypad5" => Ok(76),
+        "kp6" | "keypad6" => Ok(77),
+        "kpplus" | "keypadplus" | "kpadd" => Ok(78),
+        "kp1" | "keypad1" => Ok(79),
+        "kp2" | "keypad2" => Ok(80),
+        "kp3" | "keypad3" => Ok(81),
+        "kp0" | "keypad0" => Ok(82),
+        "kpdot" | "keypaddot" | "kpdecimal" | "kpperiod" => Ok(83),
+
+        "zenkakuhankaku" => Ok(85),
+        "102nd" => Ok(86), // Often a second backslash or <>| key on ISO layouts
+        "f11" => Ok(87),
+        "f12" => Ok(88),
+        "ro" => Ok(89), // Japanese Yen/Ro key
+        "katakana" => Ok(90),
+        "hiragana" => Ok(91),
+        "henkan" => Ok(92),
+        "katakanahiragana" => Ok(93),
+        "muhenkan" => Ok(94),
+        "kpjpcomma" | "keypadjpcomma" => Ok(95), // Japanese keypad comma
+        "kpenter" | "keypadenter" => Ok(96),
+        "rightctrl" | "rctrl" => Ok(97),
+        "kpslash" | "keypadslash" | "kpdivide" | "kpdiv" => Ok(98),
+        "sysrq" | "printscreen" | "prtscr" => Ok(99),
+        "rightalt" | "ralt" | "altgr" => Ok(100),
+        "linefeed" => Ok(101), // Not common on PC keyboards
+        "home" => Ok(102),
+        "up" | "uparrow" => Ok(103),
+        "pageup" | "pgup" => Ok(104),
+        "left" | "leftarrow" => Ok(105),
+        "right" | "rightarrow" => Ok(106),
+        "end" => Ok(107),
+        "down" | "downarrow" => Ok(108),
+        "pagedown" | "pgdn" => Ok(109),
+        "insert" | "ins" => Ok(110),
+        "delete" | "del" => Ok(111),
+        // "macro" => Ok(112), // Generic, probably not for direct use by name
+        "mute" => Ok(113),
+        "volumedown" => Ok(114),
+        "volumeup" => Ok(115),
+        "power" => Ok(116), // SC System Power Down
+        "kpequal" | "keypadequal" => Ok(117),
+        "kpplusminus" | "keypadplusminus" => Ok(118),
+        "pause" | "pausebreak" => Ok(119),
+        // "scale" => Ok(120), // AL Compiz Scale (Expose) - less common by name
+
+        "kpcomma" | "keypadcomma" => Ok(121), // Often on Brazilian/some European layouts
+        // "hangeul" | "hanguel" => Ok(122), // Korean Hangeul
+        "hanja" => Ok(123), // Korean Hanja
+        "yen" => Ok(124), // Japanese Yen (sometimes different from Ro)
+        "leftmeta" | "lmeta" | "leftwindows" | "lwin" | "leftsuper" | "lsuper" => Ok(125),
+        "rightmeta" | "rmeta" | "rightwindows" | "rwin" | "rightsuper" | "rsuper" => Ok(126),
+        "compose" => Ok(127), // Compose key
+
+        // Media keys (selection, more might be needed if desired)
+        "stop" => Ok(128), // AC Stop
+        "again" => Ok(129),
+        "props" => Ok(130), // AC Properties
+        "undo" => Ok(131), // AC Undo
+        "front" => Ok(132),
+        "copy" => Ok(133), // AC Copy
+        "open" => Ok(134), // AC Open
+        "paste" => Ok(135), // AC Paste
+        "find" => Ok(136), // AC Search
+        "cut" => Ok(137), // AC Cut
+        "help" => Ok(138), // AL Integrated Help Center
+        "menu" | "appmenu" => Ok(139), // Menu key (application menu)
+        "calc" | "calculator" => Ok(140), // AL Calculator
+        "setup" => Ok(141),
+        "sleep" => Ok(142), // SC System Sleep
+        "wakeup" => Ok(143), // System Wake Up
+        "file" => Ok(144), // AL Local Machine Browser
+        "www" => Ok(150), // AL Internet Browser
+        "mail" => Ok(155),
+        "bookmarks" => Ok(156), // AC Bookmarks
+        "computer" => Ok(157),
+        "back" => Ok(158), // AC Back
+        "forward" => Ok(159), // AC Forward
+        "ejectcd" | "eject" => Ok(161),
+        "nextsong" => Ok(163),
+        "playpause" => Ok(164),
+        "previoussong" => Ok(165),
+        "stopcd" => Ok(166), // Different from KEY_STOP
+        "record" => Ok(167),
+        "rewind" => Ok(168),
+        "phone" => Ok(169),
+        "homepage" => Ok(172), // AC Home
+        "refresh" => Ok(173), // AC Refresh
+        "exit" => Ok(174), // AC Exit
+        "scrollup" => Ok(177),
+        "scrolldown" => Ok(178),
+        "kpleftparen" | "keypadleftparen" => Ok(179),
+        "kprightparen" | "keypadrightparen" => Ok(180),
+
+        // F13-F24 (less common on physical keyboards but exist)
+        "f13" => Ok(183),
+        "f14" => Ok(184),
+        "f15" => Ok(185),
+        "f16" => Ok(186),
+        "f17" => Ok(187),
+        "f18" => Ok(188),
+        "f19" => Ok(189),
+        "f20" => Ok(190),
+        "f21" => Ok(191),
+        "f22" => Ok(192),
+        "f23" => Ok(193),
+        "f24" => Ok(194),
+
+        "playcd" => Ok(200),
+        "pausecd" => Ok(201),
+        "print" => Ok(210), // AC Print (different from PrtSc/SysRq)
+        "camera" => Ok(212),
+        "search" => Ok(217), // Often a dedicated search key
+        "brightnessdown" => Ok(224),
+        "brightnessup" => Ok(225),
+        "kbdillumtoggle" | "keyboardilluminationtoggle" => Ok(228),
+        "kbdillumdown" | "keyboardilluminationdown" => Ok(229),
+        "kbdillumup" | "keyboardilluminationup" => Ok(230),
+        "micmute" => Ok(248),
+
+        "fn" => Ok(0x1d0), // 464
+        "fnesc" => Ok(0x1d1), // 465
+        // Not adding all KEY_FN_F<N> as they are less common to specify by name
+        // and "f<N>" should cover it.
+
+        _ => Err(format!("Unknown key name: '{}'", key_name_str)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_keys() {
+        assert_eq!(get_keycode_from_string("q").unwrap(), 16);
+        assert_eq!(get_keycode_from_string("Q").unwrap(), 16);
+        assert_eq!(get_keycode_from_string("esc").unwrap(), 1);
+        assert_eq!(get_keycode_from_string("ESC").unwrap(), 1);
+        assert_eq!(get_keycode_from_string("enter").unwrap(), 28);
+        assert_eq!(get_keycode_from_string("RETURN").unwrap(), 28);
+        assert_eq!(get_keycode_from_string("space").unwrap(), 57);
+    }
+
+    #[test]
+    fn test_number_keys() {
+        assert_eq!(get_keycode_from_string("1").unwrap(), 2);
+        assert_eq!(get_keycode_from_string("0").unwrap(), 11);
+    }
+
+    #[test]
+    fn test_f_keys() {
+        assert_eq!(get_keycode_from_string("f1").unwrap(), 59);
+        assert_eq!(get_keycode_from_string("F1").unwrap(), 59);
+        assert_eq!(get_keycode_from_string("f12").unwrap(), 88);
+        assert_eq!(get_keycode_from_string("f13").unwrap(), 183);
+        assert_eq!(get_keycode_from_string("f24").unwrap(), 194);
+    }
+
+    #[test]
+    fn test_modifier_keys() {
+        assert_eq!(get_keycode_from_string("leftshift").unwrap(), 42);
+        assert_eq!(get_keycode_from_string("lshift").unwrap(), 42);
+        assert_eq!(get_keycode_from_string("rightshift").unwrap(), 54);
+        assert_eq!(get_keycode_from_string("rshift").unwrap(), 54);
+        assert_eq!(get_keycode_from_string("leftctrl").unwrap(), 29);
+        assert_eq!(get_keycode_from_string("lctrl").unwrap(), 29);
+        assert_eq!(get_keycode_from_string("rightctrl").unwrap(), 97);
+        assert_eq!(get_keycode_from_string("rctrl").unwrap(), 97);
+        assert_eq!(get_keycode_from_string("leftalt").unwrap(), 56);
+        assert_eq!(get_keycode_from_string("lalt").unwrap(), 56);
+        assert_eq!(get_keycode_from_string("rightalt").unwrap(), 100);
+        assert_eq!(get_keycode_from_string("ralt").unwrap(), 100);
+        assert_eq!(get_keycode_from_string("altgr").unwrap(), 100);
+        assert_eq!(get_keycode_from_string("leftmeta").unwrap(), 125);
+        assert_eq!(get_keycode_from_string("lmeta").unwrap(), 125);
+        assert_eq!(get_keycode_from_string("lwin").unwrap(), 125);
+        assert_eq!(get_keycode_from_string("leftsuper").unwrap(), 125);
+        assert_eq!(get_keycode_from_string("rightmeta").unwrap(), 126);
+        assert_eq!(get_keycode_from_string("rmeta").unwrap(), 126);
+        assert_eq!(get_keycode_from_string("rwin").unwrap(), 126);
+        assert_eq!(get_keycode_from_string("rightsuper").unwrap(), 126);
+    }
+
+    #[test]
+    fn test_keypad_keys() {
+        assert_eq!(get_keycode_from_string("kp0").unwrap(), 82);
+        assert_eq!(get_keycode_from_string("keypad0").unwrap(), 82);
+        assert_eq!(get_keycode_from_string("kp_0").unwrap(), 82); // Test underscore normalization
+        assert_eq!(get_keycode_from_string("kp7").unwrap(), 71);
+        assert_eq!(get_keycode_from_string("keypad7").unwrap(), 71);
+        assert_eq!(get_keycode_from_string("kpenter").unwrap(), 96);
+        assert_eq!(get_keycode_from_string("keypadenter").unwrap(), 96);
+        assert_eq!(get_keycode_from_string("kpslash").unwrap(), 98);
+        assert_eq!(get_keycode_from_string("kpdivide").unwrap(), 98);
+        assert_eq!(get_keycode_from_string("kpasterisk").unwrap(), 55);
+        assert_eq!(get_keycode_from_string("kpmultiply").unwrap(), 55);
+        assert_eq!(get_keycode_from_string("kpminus").unwrap(), 74);
+        assert_eq!(get_keycode_from_string("kpsub").unwrap(), 74);
+        assert_eq!(get_keycode_from_string("kpplus").unwrap(), 78);
+        assert_eq!(get_keycode_from_string("kpadd").unwrap(), 78);
+        assert_eq!(get_keycode_from_string("kpdot").unwrap(), 83);
+        assert_eq!(get_keycode_from_string("kpdecimal").unwrap(), 83);
+        assert_eq!(get_keycode_from_string("kpequal").unwrap(), 117);
+        assert_eq!(get_keycode_from_string("kpcomma").unwrap(), 121);
+        assert_eq!(get_keycode_from_string("kpjpcomma").unwrap(), 95);
+        assert_eq!(get_keycode_from_string("kpplusminus").unwrap(), 118);
+        assert_eq!(get_keycode_from_string("kpleftparen").unwrap(), 179);
+        assert_eq!(get_keycode_from_string("kprightparen").unwrap(), 180);
+    }
+
+    #[test]
+    fn test_symbol_keys() {
+        assert_eq!(get_keycode_from_string(".").unwrap(), 52);
+        assert_eq!(get_keycode_from_string("period").unwrap(), 52);
+        assert_eq!(get_keycode_from_string(",").unwrap(), 51);
+        assert_eq!(get_keycode_from_string("comma").unwrap(), 51);
+        assert_eq!(get_keycode_from_string("/").unwrap(), 53);
+        assert_eq!(get_keycode_from_string("slash").unwrap(), 53);
+        assert_eq!(get_keycode_from_string(";").unwrap(), 39);
+        assert_eq!(get_keycode_from_string("semicolon").unwrap(), 39);
+        assert_eq!(get_keycode_from_string("'").unwrap(), 40);
+        assert_eq!(get_keycode_from_string("apostrophe").unwrap(), 40);
+        assert_eq!(get_keycode_from_string("quote").unwrap(), 40);
+        assert_eq!(get_keycode_from_string("[").unwrap(), 26);
+        assert_eq!(get_keycode_from_string("leftbrace").unwrap(), 26);
+        assert_eq!(get_keycode_from_string("lbracket").unwrap(), 26);
+        assert_eq!(get_keycode_from_string("]").unwrap(), 27);
+        assert_eq!(get_keycode_from_string("rightbrace").unwrap(), 27);
+        assert_eq!(get_keycode_from_string("rbracket").unwrap(), 27);
+        assert_eq!(get_keycode_from_string("\\").unwrap(), 43);
+        assert_eq!(get_keycode_from_string("backslash").unwrap(), 43);
+        assert_eq!(get_keycode_from_string("`").unwrap(), 41);
+        assert_eq!(get_keycode_from_string("grave").unwrap(), 41);
+        assert_eq!(get_keycode_from_string("tilde").unwrap(), 41);
+        assert_eq!(get_keycode_from_string("-").unwrap(), 12);
+        assert_eq!(get_keycode_from_string("minus").unwrap(), 12);
+        assert_eq!(get_keycode_from_string("=").unwrap(), 13);
+        assert_eq!(get_keycode_from_string("equal").unwrap(), 13);
+    }
+
+    #[test]
+    fn test_navigation_keys() {
+        assert_eq!(get_keycode_from_string("home").unwrap(), 102);
+        assert_eq!(get_keycode_from_string("end").unwrap(), 107);
+        assert_eq!(get_keycode_from_string("pageup").unwrap(), 104);
+        assert_eq!(get_keycode_from_string("pgup").unwrap(), 104);
+        assert_eq!(get_keycode_from_string("pagedown").unwrap(), 109);
+        assert_eq!(get_keycode_from_string("pgdn").unwrap(), 109);
+        assert_eq!(get_keycode_from_string("insert").unwrap(), 110);
+        assert_eq!(get_keycode_from_string("ins").unwrap(), 110);
+        assert_eq!(get_keycode_from_string("delete").unwrap(), 111);
+        assert_eq!(get_keycode_from_string("del").unwrap(), 111);
+        assert_eq!(get_keycode_from_string("up").unwrap(), 103);
+        assert_eq!(get_keycode_from_string("uparrow").unwrap(), 103);
+        assert_eq!(get_keycode_from_string("down").unwrap(), 108);
+        assert_eq!(get_keycode_from_string("downarrow").unwrap(), 108);
+        assert_eq!(get_keycode_from_string("left").unwrap(), 105);
+        assert_eq!(get_keycode_from_string("leftarrow").unwrap(), 105);
+        assert_eq!(get_keycode_from_string("right").unwrap(), 106);
+        assert_eq!(get_keycode_from_string("rightarrow").unwrap(), 106);
+    }
+
+    #[test]
+    fn test_other_common_keys() {
+        assert_eq!(get_keycode_from_string("tab").unwrap(), 15);
+        assert_eq!(get_keycode_from_string("backspace").unwrap(), 14);
+        assert_eq!(get_keycode_from_string("bksp").unwrap(), 14);
+        assert_eq!(get_keycode_from_string("capslock").unwrap(), 58);
+        assert_eq!(get_keycode_from_string("caps").unwrap(), 58);
+        assert_eq!(get_keycode_from_string("numlock").unwrap(), 69);
+        assert_eq!(get_keycode_from_string("num").unwrap(), 69);
+        assert_eq!(get_keycode_from_string("scrolllock").unwrap(), 70);
+        assert_eq!(get_keycode_from_string("scroll").unwrap(), 70);
+        assert_eq!(get_keycode_from_string("sysrq").unwrap(), 99);
+        assert_eq!(get_keycode_from_string("printscreen").unwrap(), 99);
+        assert_eq!(get_keycode_from_string("prtscr").unwrap(), 99);
+        assert_eq!(get_keycode_from_string("pause").unwrap(), 119);
+        assert_eq!(get_keycode_from_string("pausebreak").unwrap(), 119);
+        assert_eq!(get_keycode_from_string("menu").unwrap(), 139);
+        assert_eq!(get_keycode_from_string("appmenu").unwrap(), 139);
+        assert_eq!(get_keycode_from_string("compose").unwrap(), 127);
+        assert_eq!(get_keycode_from_string("fn").unwrap(), 0x1d0);
+        assert_eq!(get_keycode_from_string("fnesc").unwrap(), 0x1d1);
+    }
+
+    #[test]
+    fn test_media_keys() {
+        assert_eq!(get_keycode_from_string("mute").unwrap(), 113);
+        assert_eq!(get_keycode_from_string("volumedown").unwrap(), 114);
+        assert_eq!(get_keycode_from_string("volumeup").unwrap(), 115);
+        assert_eq!(get_keycode_from_string("playpause").unwrap(), 164);
+        assert_eq!(get_keycode_from_string("stopcd").unwrap(), 166); // Note: KEY_STOP (128) is different
+        assert_eq!(get_keycode_from_string("nextsong").unwrap(), 163);
+        assert_eq!(get_keycode_from_string("previoussong").unwrap(), 165);
+        assert_eq!(get_keycode_from_string("eject").unwrap(), 161);
+        assert_eq!(get_keycode_from_string("ejectcd").unwrap(), 161);
+        assert_eq!(get_keycode_from_string("micmute").unwrap(), 248);
+    }
+
+
+    #[test]
+    fn test_unknown_key() {
+        assert!(get_keycode_from_string("thiskeydoesnotexist").is_err());
+        assert_eq!(
+            get_keycode_from_string("thiskeydoesnotexist").unwrap_err(),
+            "Unknown key name: 'thiskeydoesnotexist'"
+        );
+    }
+
+    #[test]
+    fn test_ambiguous_keys() {
+        assert_eq!(
+            get_keycode_from_string("shift").unwrap_err(),
+            "Ambiguous key name 'shift'. Please specify one of: leftshift, rightshift"
+        );
+        assert_eq!(
+            get_keycode_from_string("SHIFT").unwrap_err(), // Test case insensitivity for ambiguous check
+            "Ambiguous key name 'shift'. Please specify one of: leftshift, rightshift"
+        );
+        assert_eq!(
+            get_keycode_from_string("ctrl").unwrap_err(),
+            "Ambiguous key name 'ctrl'/'control'. Please specify one of: leftctrl, rightctrl"
+        );
+        assert_eq!(
+            get_keycode_from_string("control").unwrap_err(),
+            "Ambiguous key name 'ctrl'/'control'. Please specify one of: leftctrl, rightctrl"
+        );
+        assert_eq!(
+            get_keycode_from_string("alt").unwrap_err(),
+            "Ambiguous key name 'alt'. Please specify one of: leftalt, rightalt"
+        );
+        assert_eq!(
+            get_keycode_from_string("meta").unwrap_err(),
+            "Ambiguous key name 'meta'/'win'/'super'. Please specify one of: leftmeta, rightmeta (or lwin, rwin, etc.)"
+        );
+         assert_eq!(
+            get_keycode_from_string("win").unwrap_err(),
+            "Ambiguous key name 'meta'/'win'/'super'. Please specify one of: leftmeta, rightmeta (or lwin, rwin, etc.)"
+        );
+        assert_eq!(
+            get_keycode_from_string("super").unwrap_err(),
+            "Ambiguous key name 'meta'/'win'/'super'. Please specify one of: leftmeta, rightmeta (or lwin, rwin, etc.)"
+        );
+    }
+
+    #[test]
+    fn test_case_insensitivity_and_normalization() {
+        assert_eq!(get_keycode_from_string("LeFt_ShIfT").unwrap(), 42);
+        assert_eq!(get_keycode_from_string("LSHIFT").unwrap(), 42);
+        assert_eq!(get_keycode_from_string("KeyPad_eNTeR").unwrap(), 96);
+        assert_eq!(get_keycode_from_string("KPENTER").unwrap(), 96);
+        assert_eq!(get_keycode_from_string("volume-down").unwrap(), 114); // Test dash normalization
+    }
+}


### PR DESCRIPTION
- Implement `keycodes::get_keycode_from_string()` using a static match statement derived from Linux `input-event-codes.h` to convert case-insensitive key names (and aliases like "lshift", "enter") to integer keycodes.
- Handle ambiguous key names (e.g. "shift") by returning an error that guides the user to specify "leftshift" or "rightshift".
- Update `KeyConfig` to accept string or integer types for the `keycode` field in `keys.toml`.
- Make the `keycode` field optional in `keys.toml`. If omitted, the value from the `name` field is used as the key name to resolve the keycode.
- If a key name (either from an explicit string `keycode` or a defaulted `name`) cannot be resolved, the program now exits with an informative error.
- Update `keys.toml` to a default 85% TKL layout, using string key names and testing the optional keycode behavior.
- Ensure all unit tests for keycode resolution pass.