### PR TITLE
Fix(main): Resolve event loop hang by integrating poll-based Wayland …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +193,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dirs"
@@ -411,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,7 +466,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -648,6 +669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +691,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -978,6 +1020,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+
+[[package]]
 name = "ttf-parser"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1133,7 @@ dependencies = [
  "log",
  "memmap2",
  "once_cell",
+ "polling",
  "raqote",
  "regex",
  "rusttype",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7" # For flexible TOML value parsing
 regex = "1.10"      # For parsing input-event-codes.h
 once_cell = "1.19"  # For static LAZY KEYCODE_MAP
+polling = "3.7.2"   # For event polling


### PR DESCRIPTION
…event handling

The application was previously hanging on startup, likely due to an improper non-blocking event loop for Wayland, leading to the OS reporting 'Application Not Responding'.

This commit refactors the main event loop in `src/main.rs` to use `polling::Poller` for handling Wayland events. This ensures that the application waits for Wayland events efficiently without busy-looping and correctly processes them.

Key changes include:
- Added `polling` crate dependency.
- Modified the main event loop to use `poller.wait()` on the Wayland connection's file descriptor.
- Implemented logic to handle readable events by dispatching Wayland messages.
- Implemented logic to handle writable events for the Wayland FD when `conn.flush()` returns `WouldBlock`, by re-registering interest for writability with the poller.
- Ensured proper lifetime management for Wayland `Backend` and `BorrowedFd`.
- Added detailed logging throughout the Wayland initialization and event processing paths to aid future debugging.

The libinput event handling remains a periodic check within the loop for now and does not use FD polling to simplify the current set of changes. This can be a future optimization if needed.

Compiler warnings regarding 'unnecessary unsafe block' for `Poller::modify` were noted; however, as `Poller::add` and `Poller::modify` are `unsafe fn` in the `polling` crate, the `unsafe` blocks have been retained as per the function signatures. A runtime libinput permission error was also observed during testing, which is an environment configuration issue and handled gracefully by the application.