### PR TITLE
feat: Add input device access docs and headless runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,21 @@ sudo apt-get install -y sway libudev-dev libinput-dev
 
 ## Running Tests
 
-The startup test (`tests::test_startup_no_crash`) requires a Wayland environment and permissions to access . It will attempt to start `sway --headless` automatically. Ensure that `sway` is installed and accessible in your `PATH`.
+The startup test (`tests::test_startup_no_crash`) requires a Wayland environment and permissions to access input devices. It will attempt to start `sway --headless` automatically. Ensure that `sway` is installed and accessible in your `PATH`.
 
-The tests, including the startup crash detection test, can be run using:
+For the application to access keyboard input devices (e.g., `/dev/input/event*`), the user running the application must be a member of the `input` group. This is often necessary for debugging the libinput event loop or for full application functionality.
+
+**To add your user to the `input` group:**
+
+1.  Run the following command:
+    ```bash
+    sudo usermod -aG input $(whoami)
+    ```
+2.  For the group change to take effect, you must either:
+    *   Log out and log back in.
+    *   Or, for the current terminal session, run `newgrp input`. This will start a new shell session with the updated group membership. Commands needing input device access should be run from this new shell. Alternatively, you can use `sg input -c "your_command_here"` to run a specific command with the `input` group privileges.
+
+After ensuring group membership, the tests, including the startup crash detection test, can be run using:
 
 ```bash
 cargo test
@@ -65,3 +77,46 @@ After execution, `screenshot.png` will be created.
 
 **Note on Input Device Errors:**
 In environments without direct access to input devices (e.g., many CI systems), `wayland-kbd-osd` may log errors about being unable to open `/dev/input/event*` files. This is expected. The script's primary purpose is to verify that the OSD *displays* correctly; functional input reading in such restricted environments is a separate concern. The OSD should ideally still render its UI even if it cannot access physical input devices.
+
+## Debugging with `run_headless.sh`
+
+A script named `run_headless.sh` is provided for running `wayland-kbd-osd` in a headless Sway environment with input devices enabled. This is useful for debugging the libinput event loop and other input-related functionalities.
+
+**Purpose:**
+
+*   Builds the `wayland-kbd-osd` application (release mode).
+*   Starts a headless Sway session.
+*   Runs `wayland-kbd-osd` within this session, with input device access.
+*   Keeps the application and Sway running until manually terminated (Ctrl+C).
+*   Logs application output to `/tmp/app-headless.XXXXXX.log` and Sway output to `/tmp/sway-headless.XXXXXX.log`.
+
+**Dependencies:**
+
+The script requires the following to be installed and accessible in your `PATH`:
+
+*   `sway`: For the headless Wayland compositor.
+*   `dbus-run-session`: (Usually part of `dbus-x11`) For starting Sway correctly.
+*   `cargo`: For building the application.
+*   Rust development environment and other build dependencies for `wayland-kbd-osd` (see "Development Environment Setup").
+
+On Debian-based systems, these can typically be installed with:
+```bash
+sudo apt-get update
+sudo apt-get install -y sway dbus-x11 cargo # Plus libudev-dev, libinput-dev if not already installed
+```
+
+**Usage:**
+
+1.  Ensure your user is part of the `input` group and that the group membership is active for your current session (see "Running Tests" section for instructions on adding user to `input` group).
+2.  Execute the script:
+    ```bash
+    ./run_headless.sh
+    ```
+    If you haven't started a new session or used `newgrp input` after adding your user to the `input` group, you might need to run it like this:
+    ```bash
+    sg input -c "./run_headless.sh"
+    ```
+3.  The script will build the application and then run it. Logs will be printed to temporary files (paths shown in script output).
+4.  Press `Ctrl+C` to terminate the script, which will also stop `wayland-kbd-osd` and `sway`.
+
+This script is intended for active debugging. Check the application logs for information about input event processing.

--- a/run_headless.sh
+++ b/run_headless.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# --- Configuration ---
+SWAY_LOG_FILE=$(mktemp /tmp/sway-headless.XXXXXX.log)
+APP_LOG_FILE=$(mktemp /tmp/app-headless.XXXXXX.log)
+APP_NAME="$(pwd)/target/release/wayland-kbd-osd"
+
+# PIDs for cleanup
+DBUS_SWAY_PID=""
+APP_PID=""
+
+_cleanup_called=0
+cleanup() {
+    if [ "$_cleanup_called" -eq 1 ]; then return; fi
+    _cleanup_called=1
+    echo "CLEANUP: Starting cleanup..."
+
+    if [ -n "$APP_PID" ] && ps -p "$APP_PID" > /dev/null; then
+        echo "CLEANUP: Stopping application PID: $APP_PID..."
+        kill -SIGTERM "$APP_PID" 2>/dev/null
+        sleep 0.2
+        kill -SIGKILL "$APP_PID" 2>/dev/null || true
+    fi
+
+    if [ -n "$DBUS_SWAY_PID" ] && ps -p "$DBUS_SWAY_PID" > /dev/null; then
+        echo "CLEANUP: Stopping dbus-run-session PID: $DBUS_SWAY_PID (and Sway)..."
+        # Kill children of dbus-run-session (Sway) first
+        pkill -P "$DBUS_SWAY_PID" 2>/dev/null
+        sleep 0.2
+        # Then kill dbus-run-session itself
+        kill -SIGTERM "$DBUS_SWAY_PID" 2>/dev/null
+        sleep 0.2
+        kill -SIGKILL "$DBUS_SWAY_PID" 2>/dev/null || true
+    fi
+
+    # Fallback: try to kill by name if PIDs weren't captured or processes are still running
+    # These are more likely to be needed if the script is killed externally before PIDs are set.
+    pkill -f "$APP_NAME" 2>/dev/null
+    pkill sway 2>/dev/null
+    pkill dbus-run-session 2>/dev/null
+
+
+    echo "CLEANUP: Sway log file: $SWAY_LOG_FILE"
+    echo "CLEANUP: App log file: $APP_LOG_FILE"
+    echo "CLEANUP: Cleanup finished."
+}
+trap cleanup EXIT SIGINT SIGTERM
+
+echo "SCRIPT: Building the application..."
+if ! cargo build --release; then
+    echo "SCRIPT: Failed to build the application. Exiting."
+    exit 1
+fi
+if [ ! -f "$APP_NAME" ]; then
+    echo "SCRIPT: Application binary not found at $APP_NAME after build. Exiting."
+    exit 1
+fi
+
+echo "SCRIPT: Starting headless Sway with dbus-run-session..."
+dbus-run-session env WLR_BACKENDS=headless sway --config /dev/null --verbose --unsupported-gpu &> "$SWAY_LOG_FILE" &
+DBUS_SWAY_PID=$!
+echo "SCRIPT: dbus-run-session PID: $DBUS_SWAY_PID. Waiting for Sway to initialize..."
+
+WAYLAND_DISPLAY_NAME=""
+for i in {1..15}; do
+    if ! ps -p "$DBUS_SWAY_PID" > /dev/null; then
+        echo "SCRIPT: Sway (dbus-run-session PID: $DBUS_SWAY_PID) exited prematurely. Logs:"
+        cat "$SWAY_LOG_FILE"
+        exit 1
+    fi
+    WAYLAND_DISPLAY_NAME=$(grep -oP "Running compositor on wayland display '\Kwayland-\d+(?='\s*$)" "$SWAY_LOG_FILE" || true)
+    if [ -n "$WAYLAND_DISPLAY_NAME" ]; then
+        echo "SCRIPT: Found WAYLAND_DISPLAY: $WAYLAND_DISPLAY_NAME"
+        break
+    fi
+    sleep_duration=$(awk -v i="$i" 'BEGIN { print i * 0.1 + 0.5 }')
+    sleep "$sleep_duration"
+done
+
+if [ -z "$WAYLAND_DISPLAY_NAME" ]; then
+    echo "SCRIPT: Failed to find WAYLAND_DISPLAY in Sway's log ($SWAY_LOG_FILE) after waiting."
+    cat "$SWAY_LOG_FILE"
+    exit 1
+fi
+
+echo "SCRIPT: Starting $APP_NAME on WAYLAND_DISPLAY=$WAYLAND_DISPLAY_NAME..."
+WAYLAND_DISPLAY="$WAYLAND_DISPLAY_NAME" "$APP_NAME" &> "$APP_LOG_FILE" &
+APP_PID=$!
+echo "SCRIPT: $APP_NAME started with PID $APP_PID."
+echo "SCRIPT: Running until APP ($APP_PID) exits or script is terminated externally."
+
+# Wait for the application to exit by itself.
+# If the script is killed externally, the EXIT trap will run cleanup.
+wait "$APP_PID"
+APP_EXIT_CODE=$?
+echo "SCRIPT: Application (PID $APP_PID) exited with code $APP_EXIT_CODE. Script will now exit."
+# Cleanup will be called by EXIT trap.
+exit $APP_EXIT_CODE


### PR DESCRIPTION


This commit introduces two main changes:

1.  Updates `AGENTS.md` to include:
    - Instructions on how to add the executing user to the `input`
      group to allow access to /dev/input/event* devices. This is
      necessary for debugging libinput functionality.
    - Documentation for a new `run_headless.sh` script.

2.  Adds the `run_headless.sh` script:
    - This script is adapted from `take_screenshot.sh`.
    - It builds the application and runs it in a headless Sway session
      *without* `WLR_LIBINPUT_NO_DEVICES=1`, intending to allow
      libinput to access input devices.
    - The script is designed to run the application in the foreground
      of its core logic and will run until externally terminated.

Challenges Encountered:
- Attempts to add reliable self-timeout logic to `run_headless.sh`
  for automated testing were unsuccessful within the agent's execution
  environment, consistently leading to tool timeouts.
- An attempt to refactor the main event loop in `src/main.rs` using
  the `polling` crate (to improve libinput event handling)
  was made. However, this resulted in compilation times exceeding
  the agent environment's limits, preventing the build and testing
  of this fix. These changes to `src/main.rs` and `Cargo.toml`
  have been reverted to maintain a buildable state.

The libinput event loop may still have issues related to its current
dispatch mechanism, as identified by static analysis, but a fix could
not be delivered due to the aforementioned environmental limitations.