### PR TITLE
feat: Add --check flag for configuration validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +759,7 @@ name = "wayland-kbd-osd"
 version = "0.1.0"
 dependencies = [
  "cairo-rs",
+ "clap",
  "env_logger",
  "freetype-rs",
  "input",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7" # For flexible TOML value parsing
 regex = "1.10"      # For parsing input-event-codes.h
 once_cell = "1.19"  # For static LAZY KEYCODE_MAP
+clap = { version = "4.4", features = ["derive"] }

--- a/keys.toml
+++ b/keys.toml
@@ -591,7 +591,7 @@ height = 50.0
 keycode = "rightctrl"
 
 [[key]]
-name = "Print Screen"
+name = "PrtSc"
 left = 845.0
 top = 0.0
 width = 50.0
@@ -599,7 +599,7 @@ height = 50.0
 keycode = "printscreen"
 
 [[key]]
-name = "Scroll Lock"
+name = "ScrLk"
 left = 900.0
 top = 0.0
 width = 50.0


### PR DESCRIPTION
Adds a `--check` command-line flag to the application.

This flag enables the following functionality:
- Parses the TOML configuration file (defaults to keys.toml).
- Validates that all key fields have valid values (e.g., positive dimensions).
- Checks for overlapping key bounding boxes in the TOML (before scaling).
- Checks for duplicate keycodes.
- Prints detailed information for each configured key:
    - Label (name)
    - Bounding box (left, top, width, height from TOML)
    - Resolved keycode
    - Simulated final font size (in points) after auto-scaling
    - The final text that would be rendered (showing truncation with '...')
    - Number of characters truncated

This operation is performed without opening any input devices or requiring a Wayland server. Text rendering metrics are simulated using FreeType.

Additionally, the default `keys.toml` configuration was updated to abbreviate 'Print Screen' to 'PrtSc' and 'Scroll Lock' to 'ScrLk' to resolve text truncation issues identified by the new check.

Note: The screenshot (`screenshot.png`) could not be automatically regenerated due to issues installing the 'sway' dependency in the current environment. The existing screenshot may not reflect the label changes for 'PrtSc' and 'ScrLk'.