### PR TITLE
Refactor: Improve code quality and maintainability

### DIFF
--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -23,6 +23,8 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         _ => {} // Not an ambiguous key, proceed to main match
     }
 
+    // Match against the fully normalized key name.
+    // Normalization includes: to_lowercase(), removing '_', and removing '-' for non-symbolic names.
     match normalized_key_name.as_str() {
         // Standard Keys from input-event-codes.h
         "esc" | "escape" => Ok(1),


### PR DESCRIPTION
- Remove commented-out code and unused imports in src/main.rs.
- Refactor main event loop by extracting Wayland and libinput event handling into separate functions.
- Improve variable names for clarity (e.g., temp_f to shm_temp_file).
- Add more detailed comments to the text scaling and truncation logic in draw_single_key_cairo.
- Standardize default appearance constant definitions in src/main.rs.
- Clean up and clarify the log_if_input_device_access_denied function.
- Add a minor clarifying comment in src/keycodes.rs.