### PR TITLE
Fix: Improve overlay screen size detection and add color config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -716,7 +716,7 @@ impl AppState {
 
         // Default colors for Cairo: (R, G, B, A) with values from 0.0 to 1.0
         let border_c_cairo = (0x80 as f64 / 255.0, 0x80 as f64 / 255.0, 0x80 as f64 / 255.0, 0xFF as f64 / 255.0);
-        let background_c_default_cairo = (0xE0 as f64 / 255.0, 0xE0 as f64 / 255.0, 0xE0 as f64 / 255.0, 0xFF as f64 / 255.0);
+        // let background_c_default_cairo = (0xE0 as f64 / 255.0, 0xE0 as f64 / 255.0, 0xE0 as f64 / 255.0, 0xFF as f64 / 255.0); // No longer used directly
         let background_c_pressed_cairo = (0xA0 as f64 / 255.0, 0xA0 as f64 / 255.0, 0xF0 as f64 / 255.0, 0xFF as f64 / 255.0);
         let text_c_cairo = (0x10 as f64 / 255.0, 0x10 as f64 / 255.0, 0x10 as f64 / 255.0, 0xFF as f64 / 255.0);
 


### PR DESCRIPTION
- Modified the overlay mode logic to wait for Wayland screen dimension
  events (zxdg_output logical_size) before calculating the overlay
  surface size. This should prevent the overlay from incorrectly using
  fallback dimensions (e.g., 320x240) when actual screen dimensions
  were not yet processed.
- Changed the default overlay background to be fully transparent (#00000000).
- Added global configuration for default key background color via
  `[overlay].default_key_background_color` in `keys.toml`,
  defaulting to translucent light grey (#E0E0E080).
- Added per-key configuration for `background_color` in `keys.toml`.
- Updated drawing logic to prioritize per-key, then global, then
  hardcoded default for inactive key backgrounds.
- Updated `--check` command to display the new global default key
  background color setting.