### PR TITLE
Fix(wayland): Adjust layer shell anchors for Hyprland compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ After ensuring group membership, the tests, including the startup crash detectio
 cargo test
 ```
 
+**IMPORTANT:** `cargo test` MUST be run to validate any code changes before submitting them. All tests should pass.
+
 ## Visual Inspection with `take_screenshot.sh`
 
 A script named `take_screenshot.sh` is provided to help with visual inspection of `wayland-kbd-osd` running in a headless Sway environment. This is particularly useful for agents or automated systems that need to verify the visual output of the OSD.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1740,16 +1740,18 @@ fn main() {
             );
             // Configure the layer surface
             let anchor = match app_state.config.overlay.position {
-                OverlayPosition::Top => zwlr_layer_surface_v1::Anchor::Top,
-                OverlayPosition::Bottom => zwlr_layer_surface_v1::Anchor::Bottom,
+                OverlayPosition::Top | OverlayPosition::TopCenter => {
+                    zwlr_layer_surface_v1::Anchor::Top | zwlr_layer_surface_v1::Anchor::Left | zwlr_layer_surface_v1::Anchor::Right
+                }
+                OverlayPosition::Bottom | OverlayPosition::BottomCenter => {
+                    zwlr_layer_surface_v1::Anchor::Bottom | zwlr_layer_surface_v1::Anchor::Left | zwlr_layer_surface_v1::Anchor::Right
+                }
                 OverlayPosition::Left => zwlr_layer_surface_v1::Anchor::Left,
                 OverlayPosition::Right => zwlr_layer_surface_v1::Anchor::Right,
-                OverlayPosition::Center => zwlr_layer_surface_v1::Anchor::empty(), // Centered by default if no anchor
+                OverlayPosition::Center => zwlr_layer_surface_v1::Anchor::empty(), // Centered by default if no anchor. If set_size(0,0) this might need L+R too, but error was for Bottom.
                 OverlayPosition::TopLeft => zwlr_layer_surface_v1::Anchor::Top | zwlr_layer_surface_v1::Anchor::Left,
-                OverlayPosition::TopCenter => zwlr_layer_surface_v1::Anchor::Top, // Rely on centering for horizontal
                 OverlayPosition::TopRight => zwlr_layer_surface_v1::Anchor::Top | zwlr_layer_surface_v1::Anchor::Right,
                 OverlayPosition::BottomLeft => zwlr_layer_surface_v1::Anchor::Bottom | zwlr_layer_surface_v1::Anchor::Left,
-                OverlayPosition::BottomCenter => zwlr_layer_surface_v1::Anchor::Bottom, // Rely on centering for horizontal
                 OverlayPosition::BottomRight => zwlr_layer_surface_v1::Anchor::Bottom | zwlr_layer_surface_v1::Anchor::Right,
                 OverlayPosition::CenterLeft => zwlr_layer_surface_v1::Anchor::Left, // Rely on centering for vertical
                 OverlayPosition::CenterRight => zwlr_layer_surface_v1::Anchor::Right, // Rely on centering for vertical


### PR DESCRIPTION
Ensure Top/Bottom anchors also include Left/Right for set_size(0,0). This resolves a protocol error on Hyprland. Updates AGENTS.md.