### PR TITLE
Refactor: Split application logic into modules

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,594 @@
+// Configuration loading and related structs
+use serde::Deserialize;
+use serde_value::Value as SerdeValue;
+use std::collections::HashMap;
+use std::fs;
+// use std::process; // This was unused
+
+use crate::keycodes;
+
+// Represents a size that can be absolute (pixels) or relative (ratio of screen)
+#[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(untagged)] // Allows parsing "100" as pixels(100) or "0.5" as ratio(0.5)
+pub enum SizeDimension {
+    Pixels(u32),
+    Ratio(f32),
+}
+
+// Enum for specifying overlay position
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayPosition {
+    Top,
+    Bottom,
+    Left,
+    Right,
+    Center,
+    TopLeft,
+    TopCenter,
+    TopRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    CenterLeft,
+    CenterRight,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct OverlayConfig {
+    #[serde(default)]
+    pub screen: Option<String>,
+    #[serde(default = "default_overlay_position")]
+    pub position: OverlayPosition,
+    pub size_width: Option<SizeDimension>,
+    pub size_height: Option<SizeDimension>,
+    #[serde(default = "default_overlay_margin")]
+    pub margin_top: i32,
+    #[serde(default = "default_overlay_margin")]
+    pub margin_right: i32,
+    #[serde(default = "default_overlay_margin")]
+    pub margin_bottom: i32,
+    #[serde(default = "default_overlay_margin")]
+    pub margin_left: i32,
+    #[serde(default = "default_background_color_inactive")]
+    pub background_color_inactive: String,
+    #[serde(default = "default_background_color_active")]
+    pub background_color_active: String,
+    #[serde(default = "default_key_background_color_string")]
+    pub default_key_background_color: String,
+    #[serde(default = "default_key_text_color_string")]
+    pub default_key_text_color: String,
+    #[serde(default = "default_key_outline_color_string")]
+    pub default_key_outline_color: String,
+    #[serde(default = "default_active_key_background_color_string")]
+    pub active_key_background_color: String,
+    #[serde(default = "default_active_key_text_color_string")]
+    pub active_key_text_color: String,
+}
+
+fn default_overlay_position() -> OverlayPosition {
+    OverlayPosition::BottomCenter
+}
+fn default_overlay_margin() -> i32 {
+    0
+}
+fn default_background_color_inactive() -> String {
+    "#00000000".to_string()
+}
+fn default_background_color_active() -> String {
+    "#A0A0A0D0".to_string()
+}
+pub fn default_key_background_color_string() -> String {
+    "#4D4D4D80".to_string()
+}
+fn default_key_text_color_string() -> String {
+    "#B3B3B3CC".to_string()
+}
+fn default_key_outline_color_string() -> String {
+    "#B3B3B3CC".to_string()
+}
+fn default_active_key_background_color_string() -> String {
+    "#A0A0F0FF".to_string()
+}
+fn default_active_key_text_color_string() -> String {
+    default_key_text_color_string()
+}
+
+impl Default for OverlayConfig {
+    fn default() -> Self {
+        OverlayConfig {
+            screen: None,
+            position: default_overlay_position(),
+            size_width: None,
+            size_height: Some(SizeDimension::Ratio(0.3)),
+            margin_top: default_overlay_margin(),
+            margin_right: default_overlay_margin(),
+            margin_bottom: default_overlay_margin(),
+            margin_left: default_overlay_margin(),
+            background_color_inactive: default_background_color_inactive(),
+            background_color_active: default_background_color_active(),
+            default_key_background_color: default_key_background_color_string(),
+            default_key_text_color: default_key_text_color_string(),
+            default_key_outline_color: default_key_outline_color_string(),
+            active_key_background_color: default_active_key_background_color_string(),
+            active_key_text_color: default_active_key_text_color_string(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct KeyConfig {
+    pub name: String,
+    pub width: f32,
+    pub height: f32,
+    pub left: f32,
+    pub top: f32,
+    #[serde(alias = "keycode")]
+    pub raw_keycode: Option<SerdeValue>,
+    #[serde(skip_deserializing)]
+    pub keycode: u32,
+    pub rotation_degrees: Option<f32>,
+    pub text_size: Option<f32>,
+    pub corner_radius: Option<f32>,
+    pub border_thickness: Option<f32>,
+    pub background_color: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct AppConfig {
+    #[serde(default)]
+    pub key: Vec<KeyConfig>,
+    #[serde(default)]
+    pub overlay: OverlayConfig,
+}
+
+// Helper function to parse color string like "#RRGGBBAA" or "#RGB"
+// Returns (r, g, b, a) tuple with values from 0.0 to 1.0
+pub fn parse_color_string(color_str: &str) -> Result<(f64, f64, f64, f64), String> {
+    let s = color_str.trim_start_matches('#');
+    match s.len() {
+        6 => {
+            // RRGGBB
+            let r = u8::from_str_radix(&s[0..2], 16)
+                .map_err(|e| format!("Invalid hex for R: {}", e))?;
+            let g = u8::from_str_radix(&s[2..4], 16)
+                .map_err(|e| format!("Invalid hex for G: {}", e))?;
+            let b = u8::from_str_radix(&s[4..6], 16)
+                .map_err(|e| format!("Invalid hex for B: {}", e))?;
+            Ok((r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0, 1.0)) // Default alpha to 1.0
+        }
+        8 => {
+            // RRGGBBAA
+            let r = u8::from_str_radix(&s[0..2], 16)
+                .map_err(|e| format!("Invalid hex for R: {}", e))?;
+            let g = u8::from_str_radix(&s[2..4], 16)
+                .map_err(|e| format!("Invalid hex for G: {}", e))?;
+            let b = u8::from_str_radix(&s[4..6], 16)
+                .map_err(|e| format!("Invalid hex for B: {}", e))?;
+            let a = u8::from_str_radix(&s[6..8], 16)
+                .map_err(|e| format!("Invalid hex for A: {}", e))?;
+            Ok((
+                r as f64 / 255.0,
+                g as f64 / 255.0,
+                b as f64 / 255.0,
+                a as f64 / 255.0,
+            ))
+        }
+        3 => {
+            // RGB
+            let r_char = s.chars().next().unwrap();
+            let g_char = s.chars().nth(1).unwrap();
+            let b_char = s.chars().nth(2).unwrap();
+            let r = u8::from_str_radix(&format!("{}{}", r_char, r_char), 16)
+                .map_err(|e| format!("Invalid hex for R: {}", e))?;
+            let g = u8::from_str_radix(&format!("{}{}", g_char, g_char), 16)
+                .map_err(|e| format!("Invalid hex for G: {}", e))?;
+            let b = u8::from_str_radix(&format!("{}{}", b_char, b_char), 16)
+                .map_err(|e| format!("Invalid hex for B: {}", e))?;
+            Ok((r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0, 1.0))
+        }
+        4 => {
+            // RGBA
+            let r_char = s.chars().next().unwrap();
+            let g_char = s.chars().nth(1).unwrap();
+            let b_char = s.chars().nth(2).unwrap();
+            let a_char = s.chars().nth(3).unwrap();
+            let r = u8::from_str_radix(&format!("{}{}", r_char, r_char), 16)
+                .map_err(|e| format!("Invalid hex for R: {}", e))?;
+            let g = u8::from_str_radix(&format!("{}{}", g_char, g_char), 16)
+                .map_err(|e| format!("Invalid hex for G: {}", e))?;
+            let b = u8::from_str_radix(&format!("{}{}", b_char, b_char), 16)
+                .map_err(|e| format!("Invalid hex for B: {}", e))?;
+            let a = u8::from_str_radix(&format!("{}{}", a_char, a_char), 16)
+                .map_err(|e| format!("Invalid hex for A: {}", e))?;
+            Ok((
+                r as f64 / 255.0,
+                g as f64 / 255.0,
+                b as f64 / 255.0,
+                a as f64 / 255.0,
+            ))
+        }
+        _ => Err(format!(
+            "Invalid color string length for '{}'. Expected #RRGGBB, #RRGGBBAA, #RGB, or #RGBA",
+            color_str
+        )),
+    }
+}
+
+// Default appearance values (unscaled) - also used in check_config and AppState::draw
+pub const DEFAULT_CORNER_RADIUS_UNSCALED: f32 = 8.0;
+pub const DEFAULT_BORDER_THICKNESS_UNSCALED: f32 = 2.0;
+pub const DEFAULT_TEXT_SIZE_UNSCALED: f32 = 18.0;
+pub const DEFAULT_ROTATION_DEGREES: f32 = 0.0;
+
+// Helper function for --check: Validate configuration
+pub fn validate_config(config: &AppConfig) -> Result<(), String> {
+    // Check for overlapping keys
+    for i in 0..config.key.len() {
+        for j in (i + 1)..config.key.len() {
+            let key1 = &config.key[i];
+            let key2 = &config.key[j];
+
+            // Basic bounding box check (ignoring rotation for simplicity in this check)
+            let k1_left = key1.left;
+            let k1_right = key1.left + key1.width;
+            let k1_top = key1.top;
+            let k1_bottom = key1.top + key1.height;
+
+            let k2_left = key2.left;
+            let k2_right = key2.left + key2.width;
+            let k2_top = key2.top;
+            let k2_bottom = key2.top + key2.height;
+
+            if k1_left < k2_right && k1_right > k2_left && k1_top < k2_bottom && k1_bottom > k2_top
+            {
+                return Err(format!(
+                    "Configuration validation error: Key '{}' (at {:.1},{:.1} size {:.1}x{:.1}) overlaps with key '{}' (at {:.1},{:.1} size {:.1}x{:.1})",
+                    key1.name, key1.left, key1.top, key1.width, key1.height,
+                    key2.name, key2.left, key2.top, key2.width, key2.height
+                ));
+            }
+        }
+    }
+
+    // Check for duplicate keycodes
+    let mut keycodes_seen = HashMap::new();
+    for key_config in &config.key {
+        if let Some(existing_key_name) = keycodes_seen.get(&key_config.keycode) {
+            return Err(format!(
+                "Configuration validation error: Duplicate keycode {} detected. Used by key '{}' and key '{}'.",
+                key_config.keycode, existing_key_name, key_config.name
+            ));
+        }
+        keycodes_seen.insert(key_config.keycode, key_config.name.clone());
+    }
+
+    // Check for invalid values (e.g. negative width/height)
+    for key_config in &config.key {
+        if key_config.width <= 0.0 {
+            return Err(format!(
+                "Configuration validation error: Key '{}' has non-positive width {:.1}.",
+                key_config.name, key_config.width
+            ));
+        }
+        if key_config.height <= 0.0 {
+            return Err(format!(
+                "Configuration validation error: Key '{}' has non-positive height {:.1}.",
+                key_config.name, key_config.height
+            ));
+        }
+        if let Some(ts) = key_config.text_size {
+            if ts <= 0.0 {
+                return Err(format!(
+                    "Configuration validation error: Key '{}' has non-positive text_size {:.1}.",
+                    key_config.name, ts
+                ));
+            }
+        }
+        if let Some(cr) = key_config.corner_radius {
+            if cr < 0.0 {
+                return Err(format!(
+                    "Configuration validation error: Key '{}' has negative corner_radius {:.1}.",
+                    key_config.name, cr
+                ));
+            }
+        }
+        if let Some(bt) = key_config.border_thickness {
+            if bt < 0.0 {
+                return Err(format!(
+                    "Configuration validation error: Key '{}' has negative border_thickness {:.1}.",
+                    key_config.name, bt
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn print_overlay_config_for_check(config: &OverlayConfig) {
+    println!("\nOverlay Configuration:");
+    println!(
+        "  Screen:               {}",
+        config.screen.as_deref().unwrap_or("Compositor default")
+    );
+    println!("  Position:             {:?}", config.position);
+
+    let width_str = match config.size_width {
+        Some(SizeDimension::Pixels(px)) => format!("{}px", px),
+        Some(SizeDimension::Ratio(r)) => format!("{:.0}% screen", r * 100.0),
+        None => "Derived from height/layout".to_string(),
+    };
+    let height_str = match config.size_height {
+        Some(SizeDimension::Pixels(px)) => format!("{}px", px),
+        Some(SizeDimension::Ratio(r)) => format!("{:.0}% screen", r * 100.0),
+        None => "Derived from width/layout".to_string(),
+    };
+    println!("  Size Width:           {}", width_str);
+    println!("  Size Height:          {}", height_str);
+
+    println!(
+        "  Margins (T,R,B,L):    {}, {}, {}, {}",
+        config.margin_top, config.margin_right, config.margin_bottom, config.margin_left
+    );
+
+    match parse_color_string(&config.background_color_inactive) {
+        Ok((r, g, b, a)) => println!(
+            "  Background Inactive:  {} (R:{:.2} G:{:.2} B:{:.2} A:{:.2})",
+            config.background_color_inactive, r, g, b, a
+        ),
+        Err(e) => println!(
+            "  Background Inactive:  {} (Error: {})",
+            config.background_color_inactive, e
+        ),
+    }
+    match parse_color_string(&config.background_color_active) {
+        Ok((r,g,b,a)) => println!("  Background Active:    {} (R:{:.2} G:{:.2} B:{:.2} A:{:.2}) (currently unused for global bg)", config.background_color_active, r,g,b,a),
+        Err(e) => println!("  Background Active:    {} (Error: {})", config.background_color_active, e),
+    }
+    match parse_color_string(&config.default_key_background_color) {
+        Ok((r, g, b, a)) => println!(
+            "  Default Key BG:       {} (R:{:.2} G:{:.2} B:{:.2} A:{:.2})",
+            config.default_key_background_color, r, g, b, a
+        ),
+        Err(e) => println!(
+            "  Default Key BG:       {} (Error: {})",
+            config.default_key_background_color, e
+        ),
+    }
+}
+
+// Helper struct for --check: Text metrics simulation result
+pub struct TextCheckResult {
+    pub final_font_size_pts: f64,
+    pub truncated_chars: usize,
+    pub final_text: String,
+}
+
+// Helper function for --check: Simulate text scaling and truncation
+pub fn simulate_text_layout(
+    key_config: &KeyConfig,
+    ft_face: &freetype::Face,
+) -> Result<TextCheckResult, String> {
+    let original_text = key_config.name.clone();
+    let key_width = key_config.width as f64;
+    let key_height = key_config.height as f64;
+
+    let original_font_size_pts = key_config.text_size.unwrap_or(DEFAULT_TEXT_SIZE_UNSCALED) as f64;
+
+    let text_padding = (key_width * 0.1).min(key_height * 0.1).max(2.0);
+    let max_text_width_px = key_width - 2.0 * text_padding;
+
+    let min_font_size_pts = (original_font_size_pts * 0.5).max(6.0);
+
+    let mut current_text = original_text.clone();
+    let mut current_font_size_pts = original_font_size_pts;
+    let mut truncated_chars = 0;
+
+    let get_ft_text_width = |text: &str,
+                             size_pts: f64,
+                             face: &freetype::Face|
+     -> Result<f64, String> {
+        let pixel_height = size_pts.round() as u32;
+        if pixel_height == 0 {
+            return Ok(0.0);
+        }
+
+        face.set_pixel_sizes(0, pixel_height)
+            .map_err(|e| format!("FreeType set_pixel_sizes failed: {:?}", e))?;
+
+        let mut total_width = 0.0;
+        for char_code in text.chars() {
+            face.load_char(char_code as usize, freetype::face::LoadFlag::RENDER)
+                .map_err(|e| format!("FreeType load_char failed for '{}': {:?}", char_code, e))?;
+            total_width += face.glyph().advance().x as f64 / 64.0;
+        }
+        Ok(total_width)
+    };
+
+    let mut text_width_px = get_ft_text_width(&current_text, current_font_size_pts, ft_face)?;
+
+    while text_width_px > max_text_width_px && current_font_size_pts > min_font_size_pts {
+        current_font_size_pts *= 0.9;
+        if current_font_size_pts < min_font_size_pts {
+            current_font_size_pts = min_font_size_pts;
+        }
+        text_width_px = get_ft_text_width(&current_text, current_font_size_pts, ft_face)?;
+        if current_font_size_pts == min_font_size_pts && text_width_px > max_text_width_px {
+            break;
+        }
+    }
+
+    if text_width_px > max_text_width_px {
+        let ellipsis = "...";
+        let ellipsis_width_px = get_ft_text_width(ellipsis, current_font_size_pts, ft_face)?;
+
+        while text_width_px > max_text_width_px && !current_text.is_empty() {
+            // let initial_len_before_pop = current_text.chars().count(); // Unused
+            current_text.pop();
+            truncated_chars = original_text.chars().count() - current_text.chars().count();
+
+            if current_text.is_empty() {
+                current_text = if ellipsis_width_px <= max_text_width_px {
+                    ellipsis.to_string()
+                } else {
+                    "".to_string()
+                };
+                text_width_px = get_ft_text_width(&current_text, current_font_size_pts, ft_face)?;
+                break;
+            }
+
+            let temp_text_with_ellipsis = format!("{}{}", current_text, ellipsis);
+            text_width_px =
+                get_ft_text_width(&temp_text_with_ellipsis, current_font_size_pts, ft_face)?;
+
+            let current_text_only_width_px =
+                get_ft_text_width(&current_text, current_font_size_pts, ft_face)?;
+            if current_text_only_width_px + ellipsis_width_px <= max_text_width_px {
+                current_text = temp_text_with_ellipsis;
+                text_width_px = get_ft_text_width(&current_text, current_font_size_pts, ft_face)?;
+                break;
+            }
+        }
+
+        if text_width_px > max_text_width_px {
+            let mut temp_ellipsis = ellipsis.to_string();
+            while get_ft_text_width(&temp_ellipsis, current_font_size_pts, ft_face)?
+                > max_text_width_px
+                && !temp_ellipsis.is_empty()
+            {
+                temp_ellipsis.pop();
+            }
+            current_text = temp_ellipsis;
+            if current_text.starts_with(ellipsis.chars().next().unwrap_or_default())
+                && current_text.len() < ellipsis.len()
+            {
+                truncated_chars = original_text.chars().count();
+            } else if current_text.is_empty() {
+                truncated_chars = original_text.chars().count();
+            }
+        }
+    }
+
+    Ok(TextCheckResult {
+        final_font_size_pts: current_font_size_pts,
+        truncated_chars,
+        final_text: current_text,
+    })
+}
+
+pub fn load_and_process_config(config_path: &str) -> Result<AppConfig, String> {
+    let config_content = fs::read_to_string(config_path)
+        .map_err(|e| format!("Failed to read configuration file '{}': {}", config_path, e))?;
+
+    let mut app_config: AppConfig = toml::from_str(&config_content).map_err(|e| {
+        format!(
+            "Failed to parse TOML configuration from '{}': {}",
+            config_path, e
+        )
+    })?;
+
+    let mut keycode_resolution_errors = Vec::new();
+    for key_conf in app_config.key.iter_mut() {
+        if key_conf.width <= 0.0 {
+            keycode_resolution_errors.push(format!(
+                "Key '{}' has invalid width: {}",
+                key_conf.name, key_conf.width
+            ));
+        }
+        if key_conf.height <= 0.0 {
+            keycode_resolution_errors.push(format!(
+                "Key '{}' has invalid height: {}",
+                key_conf.name, key_conf.height
+            ));
+        }
+
+        let resolved_code = match key_conf.raw_keycode.as_ref() {
+            Some(SerdeValue::String(s)) => keycodes::get_keycode_from_string(s),
+            Some(SerdeValue::U8(i)) => Ok(*i as u32),
+            Some(SerdeValue::U16(i)) => Ok(*i as u32),
+            Some(SerdeValue::U32(i)) => Ok(*i),
+            Some(SerdeValue::U64(i)) => {
+                if *i <= u32::MAX as u64 {
+                    Ok(*i as u32)
+                } else {
+                    Err(format!(
+                        "Integer keycode {} for key '{}' is too large for u32.",
+                        i, key_conf.name
+                    ))
+                }
+            }
+            Some(SerdeValue::I8(i)) => {
+                if *i >= 0 {
+                    Ok(*i as u32)
+                } else {
+                    Err(format!(
+                        "Negative keycode {} for key '{}' is invalid.",
+                        i, key_conf.name
+                    ))
+                }
+            }
+            Some(SerdeValue::I16(i)) => {
+                if *i >= 0 {
+                    Ok(*i as u32)
+                } else {
+                    Err(format!(
+                        "Negative keycode {} for key '{}' is invalid.",
+                        i, key_conf.name
+                    ))
+                }
+            }
+            Some(SerdeValue::I32(i)) => {
+                if *i >= 0 {
+                    Ok(*i as u32)
+                } else {
+                    Err(format!(
+                        "Negative keycode {} for key '{}' is invalid.",
+                        i, key_conf.name
+                    ))
+                }
+            }
+            Some(SerdeValue::I64(i)) => {
+                if *i >= 0 && *i <= u32::MAX as i64 {
+                    Ok(*i as u32)
+                } else {
+                    Err(format!(
+                        "Integer keycode {} for key '{}' is out of valid u32 range.",
+                        i, key_conf.name
+                    ))
+                }
+            }
+            None => keycodes::get_keycode_from_string(&key_conf.name),
+            Some(other_type) => Err(format!(
+                "Invalid type for keycode field for key '{}': expected string or integer, got {:?}",
+                key_conf.name, other_type
+            )),
+        };
+
+        match resolved_code {
+            Ok(code) => key_conf.keycode = code,
+            Err(e) => {
+                let error_msg = if key_conf.raw_keycode.is_none() {
+                    format!(
+                        "Error processing key '{}': Could not resolve default keycode from name ('{}'). Please specify a 'keycode' field. Details: {}",
+                        key_conf.name, key_conf.name, e
+                    )
+                } else {
+                    format!(
+                        "Error processing keycode for key '{}': {}",
+                        key_conf.name, e
+                    )
+                };
+                keycode_resolution_errors.push(error_msg);
+            }
+        }
+    }
+
+    if !keycode_resolution_errors.is_empty() {
+        return Err(format!(
+            "Errors found during keycode resolution:\n- {}",
+            keycode_resolution_errors.join("\n- ")
+        ));
+    }
+
+    Ok(app_config)
+}

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,0 +1,223 @@
+// Drawing the keyboard
+
+use cairo::{Context, FontFace as CairoFontFace};
+// FreeTypeLibrary is not directly used here if font face is passed in.
+// use freetype::{Library as FreeTypeLibrary};
+
+use crate::config::parse_color_string; // Only parse_color_string is needed for background
+                                       // KeyConfig was unused here as KeyDisplay is now fully populated by AppState::draw
+                                       // use crate::config::{KeyConfig, parse_color_string, default_key_background_color_string,
+                                       //                     DEFAULT_CORNER_RADIUS_UNSCALED, DEFAULT_BORDER_THICKNESS_UNSCALED,
+                                       //                     DEFAULT_TEXT_SIZE_UNSCALED, DEFAULT_ROTATION_DEGREES};
+                                       // use wayland_client::QueueHandle; // Not directly used here
+                                       // use wayland_client::protocol::wl_shm; // Not directly used here
+
+// Struct to hold key properties for drawing (calculated from KeyConfig and AppState)
+// This struct is prepared by AppState::draw and passed to paint_all_keys
+#[derive(Debug)]
+pub struct KeyDisplay {
+    pub text: String,
+    pub center_x: f32,
+    pub center_y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub corner_radius: f32,
+    pub border_thickness: f32,
+    pub rotation_degrees: f32,
+    pub text_size: f32,
+    pub border_color: (f64, f64, f64, f64),
+    pub background_color: (f64, f64, f64, f64),
+    pub text_color: (f64, f64, f64, f64),
+}
+
+// New function using Cairo, to be called for each key by the main draw loop/function
+// This function can remain pub if there's a reason to draw single keys independently,
+// otherwise, it could be private to this module. For now, pub is fine.
+pub fn draw_single_key_cairo(ctx: &Context, key: &KeyDisplay) {
+    let x = key.center_x as f64;
+    let y = key.center_y as f64;
+    let width = key.width as f64;
+    let height = key.height as f64;
+    let corner_radius = key.corner_radius as f64;
+    let border_thickness = key.border_thickness as f64;
+    let rotation_radians = key.rotation_degrees.to_radians() as f64;
+
+    ctx.save().expect("Failed to save cairo context state");
+
+    ctx.translate(x, y);
+    ctx.rotate(rotation_radians);
+    ctx.translate(-width / 2.0, -height / 2.0);
+
+    ctx.new_sub_path();
+    ctx.arc(
+        width - corner_radius,
+        corner_radius,
+        corner_radius,
+        -std::f64::consts::PI / 2.0,
+        0.0,
+    );
+    ctx.arc(
+        width - corner_radius,
+        height - corner_radius,
+        corner_radius,
+        0.0,
+        std::f64::consts::PI / 2.0,
+    );
+    ctx.arc(
+        corner_radius,
+        height - corner_radius,
+        corner_radius,
+        std::f64::consts::PI / 2.0,
+        std::f64::consts::PI,
+    );
+    ctx.arc(
+        corner_radius,
+        corner_radius,
+        corner_radius,
+        std::f64::consts::PI,
+        3.0 * std::f64::consts::PI / 2.0,
+    );
+    ctx.close_path();
+
+    let (r, g, b, a) = key.background_color;
+    ctx.set_source_rgba(r, g, b, a);
+    ctx.fill_preserve().expect("Cairo fill failed");
+
+    let (r, g, b, a) = key.border_color;
+    ctx.set_source_rgba(r, g, b, a);
+    ctx.set_line_width(border_thickness);
+    ctx.stroke().expect("Cairo stroke failed");
+
+    let (r, g, b, a) = key.text_color;
+    ctx.set_source_rgba(r, g, b, a);
+
+    let mut current_text = key.text.clone();
+    let mut current_font_size = key.text_size as f64;
+    // Font face is set once before calling paint_all_keys
+    ctx.set_font_size(current_font_size);
+
+    let text_padding = (key.width * 0.1).min(key.height * 0.1).max(2.0) as f64;
+    let max_text_width = width - 2.0 * text_padding;
+    let original_font_size = key.text_size as f64;
+    let min_font_size = (original_font_size * 0.5).max(6.0);
+
+    let mut text_extents = ctx
+        .text_extents(&current_text)
+        .expect("Failed to get text extents (initial)");
+
+    while text_extents.width() > max_text_width && current_font_size > min_font_size {
+        current_font_size *= 0.9;
+        if current_font_size < min_font_size {
+            current_font_size = min_font_size;
+        }
+        ctx.set_font_size(current_font_size);
+        text_extents = ctx
+            .text_extents(&current_text)
+            .expect("Failed to get text extents (scaling)");
+        if current_font_size == min_font_size && text_extents.width() > max_text_width {
+            break;
+        }
+    }
+
+    if text_extents.width() > max_text_width {
+        let ellipsis = "...";
+        let ellipsis_extents = ctx
+            .text_extents(ellipsis)
+            .expect("Failed to get ellipsis extents");
+        let max_width_for_text_with_ellipsis = max_text_width - ellipsis_extents.width();
+
+        while text_extents.width() > max_text_width && !current_text.is_empty() {
+            current_text.pop();
+            let temp_text_with_ellipsis = if current_text.is_empty() {
+                if ellipsis_extents.width() <= max_text_width {
+                    ellipsis.to_string()
+                } else {
+                    "".to_string()
+                }
+            } else {
+                format!("{}{}", current_text, ellipsis)
+            };
+            text_extents = ctx
+                .text_extents(&temp_text_with_ellipsis)
+                .expect("Failed to get text extents (truncating)");
+            let current_text_only_extents = ctx
+                .text_extents(&current_text)
+                .expect("Failed to get current_text extents");
+            if current_text_only_extents.width() <= max_width_for_text_with_ellipsis
+                || current_text.is_empty()
+            {
+                current_text = temp_text_with_ellipsis;
+                text_extents = ctx
+                    .text_extents(&current_text)
+                    .expect("Failed to get final truncated text extents");
+                break;
+            }
+        }
+        if text_extents.width() > max_text_width {
+            if ellipsis_extents.width() <= max_text_width {
+                current_text = ellipsis.to_string();
+            } else if ctx.text_extents("..").unwrap().width() <= max_text_width {
+                current_text = "..".to_string();
+            } else if ctx.text_extents(".").unwrap().width() <= max_text_width {
+                current_text = ".".to_string();
+            } else {
+                current_text = "".to_string();
+            }
+        }
+    }
+
+    let text_extents = ctx
+        .text_extents(&current_text)
+        .expect("Failed to get text extents (final)");
+    let text_x = (width - text_extents.width()) / 2.0 - text_extents.x_bearing();
+    let text_y = (height - text_extents.height()) / 2.0 - text_extents.y_bearing();
+
+    ctx.move_to(text_x, text_y);
+    ctx.show_text(&current_text)
+        .expect("Cairo show_text failed");
+
+    ctx.restore()
+        .expect("Failed to restore cairo context state");
+}
+
+pub fn paint_all_keys(
+    ctx: &Context,
+    keys_to_draw: &Vec<KeyDisplay>,
+    bg_color_str: &str,
+    font_face: &CairoFontFace, // Font face is now passed in
+) {
+    // Clear the surface with configured background color
+    match parse_color_string(bg_color_str) {
+        Ok((r, g, b, a)) => {
+            ctx.save().unwrap();
+            ctx.set_source_rgba(r, g, b, a);
+            ctx.set_operator(cairo::Operator::Source);
+            ctx.paint().expect("Cairo paint (clear) failed");
+            ctx.restore().unwrap();
+        }
+        Err(e) => {
+            log::error!(
+                "Failed to parse background_color_inactive '{}': {}. Using default transparent.",
+                bg_color_str,
+                e
+            );
+            ctx.save().unwrap();
+            ctx.set_source_rgba(0.0, 0.0, 0.0, 0.0); // Transparent
+            ctx.set_operator(cairo::Operator::Source);
+            ctx.paint().expect("Cairo paint (clear fallback) failed");
+            ctx.restore().unwrap();
+        }
+    }
+
+    if keys_to_draw.is_empty() {
+        log::warn!("No keys to draw.");
+        return;
+    }
+
+    ctx.set_font_face(font_face); // Set font face once
+
+    for key_spec in keys_to_draw {
+        // Font size is set per key inside draw_single_key_cairo as it's part of KeyDisplay
+        draw_single_key_cairo(ctx, key_spec);
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,57 @@
+// Input event handling
+
+use input::event::keyboard::{KeyState, KeyboardEvent, KeyboardEventTrait};
+use input::event::Event as LibinputEvent;
+use libc::{O_NONBLOCK, O_RDWR};
+use std::fs::OpenOptions;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::io::OwnedFd; // AsRawFd was unused
+use std::path::Path;
+
+// Assuming AppState is defined in wayland.rs and passed here
+use crate::wayland::AppState;
+
+pub struct MyLibinputInterface;
+
+impl input::LibinputInterface for MyLibinputInterface {
+    fn open_restricted(&mut self, path: &Path, flags: i32) -> Result<OwnedFd, i32> {
+        log::debug!("Opening path: {:?}, flags: {}", path, flags);
+        OpenOptions::new()
+            .custom_flags(O_RDWR | O_NONBLOCK) // Use the correct flags
+            .read(true)
+            .write(true)
+            .open(path)
+            .map(|file| file.into())
+            .map_err(|e| {
+                log::error!("Failed to open path {:?}: {}", path, e);
+                e.raw_os_error().unwrap_or(libc::EIO)
+            })
+    }
+    fn close_restricted(&mut self, fd: OwnedFd) {
+        drop(fd);
+        log::debug!("Closed device via OwnedFd drop");
+    }
+}
+
+pub fn handle_libinput_events(app_state: &mut AppState) {
+    if let Some(ref mut context) = app_state.input_context {
+        if context.dispatch().is_err() {
+            log::error!("Libinput dispatch error");
+            // Optionally, you might want to handle this error more robustly,
+            // e.g., by trying to re-initialize libinput or by stopping input handling.
+        }
+        for event in context.by_ref() {
+            if let LibinputEvent::Keyboard(KeyboardEvent::Key(key_event)) = event {
+                let key_code = key_event.key();
+                let pressed = key_event.key_state() == KeyState::Pressed;
+                if let Some(current_state) = app_state.key_states.get_mut(&key_code) {
+                    if *current_state != pressed {
+                        *current_state = pressed;
+                        app_state.needs_redraw = true;
+                        log::debug!("Key {} state changed to: {}", key_code, pressed);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -147,11 +147,10 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         "kpplusminus" | "keypadplusminus" => Ok(118),
         "pause" | "pausebreak" => Ok(119),
         // "scale" => Ok(120), // AL Compiz Scale (Expose) - less common by name
-
         "kpcomma" | "keypadcomma" => Ok(121), // Often on Brazilian/some European layouts
         // "hangeul" | "hanguel" => Ok(122), // Korean Hangeul
         "hanja" => Ok(123), // Korean Hanja
-        "yen" => Ok(124), // Japanese Yen (sometimes different from Ro)
+        "yen" => Ok(124),   // Japanese Yen (sometimes different from Ro)
         "leftmeta" | "lmeta" | "leftwindows" | "lwin" | "leftsuper" | "lsuper" => Ok(125),
         "rightmeta" | "rmeta" | "rightwindows" | "rwin" | "rightsuper" | "rsuper" => Ok(126),
         "compose" => Ok(127), // Compose key
@@ -160,25 +159,25 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         "stop" => Ok(128), // AC Stop
         "again" => Ok(129),
         "props" => Ok(130), // AC Properties
-        "undo" => Ok(131), // AC Undo
+        "undo" => Ok(131),  // AC Undo
         "front" => Ok(132),
-        "copy" => Ok(133), // AC Copy
-        "open" => Ok(134), // AC Open
-        "paste" => Ok(135), // AC Paste
-        "find" => Ok(136), // AC Search
-        "cut" => Ok(137), // AC Cut
-        "help" => Ok(138), // AL Integrated Help Center
-        "menu" | "appmenu" => Ok(139), // Menu key (application menu)
+        "copy" => Ok(133),                // AC Copy
+        "open" => Ok(134),                // AC Open
+        "paste" => Ok(135),               // AC Paste
+        "find" => Ok(136),                // AC Search
+        "cut" => Ok(137),                 // AC Cut
+        "help" => Ok(138),                // AL Integrated Help Center
+        "menu" | "appmenu" => Ok(139),    // Menu key (application menu)
         "calc" | "calculator" => Ok(140), // AL Calculator
         "setup" => Ok(141),
-        "sleep" => Ok(142), // SC System Sleep
+        "sleep" => Ok(142),  // SC System Sleep
         "wakeup" => Ok(143), // System Wake Up
-        "file" => Ok(144), // AL Local Machine Browser
-        "www" => Ok(150), // AL Internet Browser
+        "file" => Ok(144),   // AL Local Machine Browser
+        "www" => Ok(150),    // AL Internet Browser
         "mail" => Ok(155),
         "bookmarks" => Ok(156), // AC Bookmarks
         "computer" => Ok(157),
-        "back" => Ok(158), // AC Back
+        "back" => Ok(158),    // AC Back
         "forward" => Ok(159), // AC Forward
         "ejectcd" | "eject" => Ok(161),
         "nextsong" => Ok(163),
@@ -189,8 +188,8 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         "rewind" => Ok(168),
         "phone" => Ok(169),
         "homepage" => Ok(172), // AC Home
-        "refresh" => Ok(173), // AC Refresh
-        "exit" => Ok(174), // AC Exit
+        "refresh" => Ok(173),  // AC Refresh
+        "exit" => Ok(174),     // AC Exit
         "scrollup" => Ok(177),
         "scrolldown" => Ok(178),
         "kpleftparen" | "keypadleftparen" => Ok(179),
@@ -222,11 +221,10 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         "kbdillumup" | "keyboardilluminationup" => Ok(230),
         "micmute" => Ok(248),
 
-        "fn" => Ok(0x1d0), // 464
+        "fn" => Ok(0x1d0),    // 464
         "fnesc" => Ok(0x1d1), // 465
         // Not adding all KEY_FN_F<N> as they are less common to specify by name
         // and "f<N>" should cover it.
-
         _ => Err(format!("Unknown key name: '{}'", key_name_str)),
     }
 }
@@ -402,7 +400,6 @@ mod tests {
         assert_eq!(get_keycode_from_string("micmute").unwrap(), 248);
     }
 
-
     #[test]
     fn test_unknown_key() {
         assert!(get_keycode_from_string("thiskeydoesnotexist").is_err());
@@ -438,7 +435,7 @@ mod tests {
             get_keycode_from_string("meta").unwrap_err(),
             "Ambiguous key name 'meta'/'win'/'super'. Please specify one of: leftmeta, rightmeta (or lwin, rwin, etc.)"
         );
-         assert_eq!(
+        assert_eq!(
             get_keycode_from_string("win").unwrap_err(),
             "Ambiguous key name 'meta'/'win'/'super'. Please specify one of: leftmeta, rightmeta (or lwin, rwin, etc.)"
         );

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -1,0 +1,787 @@
+// Wayland interaction
+ // Added for input::Libinput
+use wayland_client::protocol::{
+    wl_buffer, wl_compositor, wl_output, wl_registry, wl_shm, wl_shm_pool, wl_surface,
+};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle};
+use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+use wayland_protocols::xdg::xdg_output::zv1::client::{zxdg_output_manager_v1, zxdg_output_v1};
+use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
+
+use memmap2::MmapMut;
+use std::collections::HashMap;
+use std::fs::File as StdFsFile;
+use std::os::unix::io::AsRawFd;
+
+use crate::config::{
+    default_key_background_color_string, parse_color_string, AppConfig, SizeDimension,
+    DEFAULT_BORDER_THICKNESS_UNSCALED, DEFAULT_CORNER_RADIUS_UNSCALED, DEFAULT_ROTATION_DEGREES,
+    DEFAULT_TEXT_SIZE_UNSCALED,
+};
+use crate::draw::{self, KeyDisplay}; // Import draw module and KeyDisplay
+
+// Graphics and Font rendering (needed for font loading in AppState::draw)
+use cairo::FontFace as CairoFontFace;
+use freetype::Library as FreeTypeLibrary;
+
+pub const WINDOW_WIDTH: i32 = 320;
+pub const WINDOW_HEIGHT: i32 = 240;
+
+#[derive(Debug, Clone, Default)]
+pub struct OutputInfo {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub logical_width: i32,
+    pub logical_height: i32,
+}
+
+pub struct AppState {
+    pub compositor: Option<wl_compositor::WlCompositor>,
+    pub shm: Option<wl_shm::WlShm>,
+    pub xdg_wm_base: Option<xdg_wm_base::XdgWmBase>,
+    pub layer_shell: Option<zwlr_layer_shell_v1::ZwlrLayerShellV1>,
+    pub xdg_output_manager: Option<zxdg_output_manager_v1::ZxdgOutputManagerV1>,
+    pub outputs: Vec<(
+        u32,
+        wl_output::WlOutput,
+        Option<zxdg_output_v1::ZxdgOutputV1>,
+        OutputInfo,
+    )>,
+    pub surface: Option<wl_surface::WlSurface>,
+    pub layer_surface: Option<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1>,
+    pub buffer: Option<wl_buffer::WlBuffer>,
+    pub mmap: Option<MmapMut>,
+    pub temp_file: Option<StdFsFile>,
+    pub configured_width: i32,
+    pub configured_height: i32,
+    pub running: bool,
+    pub input_context: Option<input::Libinput>,
+    pub config: AppConfig,
+    pub key_states: HashMap<u32, bool>,
+    pub needs_redraw: bool,
+    pub last_draw_width: i32,
+    pub last_draw_height: i32,
+    pub cached_scale: f32,
+    pub cached_offset_x: f32,
+    pub cached_offset_y: f32,
+    pub layout_cache_valid: bool,
+    pub initial_surface_size_set: bool,
+    pub target_output_identifier: Option<String>,
+    pub identified_target_wl_output_name: Option<u32>,
+}
+
+impl AppState {
+    pub fn new(app_config: AppConfig) -> Self {
+        let mut key_states_map = HashMap::new();
+        for key_conf in app_config.key.iter() {
+            key_states_map.insert(key_conf.keycode, false);
+        }
+        AppState {
+            compositor: None,
+            shm: None,
+            xdg_wm_base: None,
+            layer_shell: None,
+            xdg_output_manager: None,
+            outputs: Vec::new(),
+            surface: None,
+            layer_surface: None,
+            buffer: None,
+            mmap: None,
+            temp_file: None,
+            configured_width: WINDOW_WIDTH,
+            configured_height: WINDOW_HEIGHT,
+            running: true,
+            input_context: None,
+            config: app_config.clone(),
+            key_states: key_states_map,
+            needs_redraw: true,
+            last_draw_width: 0,
+            last_draw_height: 0,
+            cached_scale: 1.0,
+            cached_offset_x: 0.0,
+            cached_offset_y: 0.0,
+            layout_cache_valid: false,
+            initial_surface_size_set: false,
+            target_output_identifier: app_config.overlay.screen.clone(),
+            identified_target_wl_output_name: None,
+        }
+    }
+
+    pub fn attempt_configure_layer_surface_size(&mut self) {
+        if self.initial_surface_size_set || self.layer_surface.is_none() || self.surface.is_none() {
+            return;
+        }
+        let mut screen_width_px = WINDOW_WIDTH;
+        let mut screen_height_px = WINDOW_HEIGHT;
+        let mut found_target_output_dimensions = false;
+        if let Some(target_wl_name) = self.identified_target_wl_output_name {
+            if let Some((_, _, _, info)) = self
+                .outputs
+                .iter()
+                .find(|(name, _, _, _)| *name == target_wl_name)
+            {
+                if info.logical_width > 0 && info.logical_height > 0 {
+                    screen_width_px = info.logical_width;
+                    screen_height_px = info.logical_height;
+                    found_target_output_dimensions = true;
+                    log::info!(
+                        "Using dimensions from targeted output (ID: {} Name: {:?}): {}x{}",
+                        target_wl_name,
+                        info.name.as_deref().unwrap_or("N/A"),
+                        screen_width_px,
+                        screen_height_px
+                    );
+                } else {
+                    log::warn!(
+                        "Targeted output (ID: {}) has invalid dimensions ({}x{}). Waiting.",
+                        target_wl_name,
+                        info.logical_width,
+                        info.logical_height
+                    );
+                    return;
+                }
+            } else {
+                log::warn!(
+                    "Previously identified target output (ID: {}) no longer found.",
+                    target_wl_name
+                );
+            }
+        }
+        if !found_target_output_dimensions {
+            if let Some((id, _, _, info)) = self
+                .outputs
+                .iter()
+                .find(|(_, _, _, i)| i.logical_width > 0 && i.logical_height > 0)
+            {
+                screen_width_px = info.logical_width;
+                screen_height_px = info.logical_height;
+                log::info!(
+                    "Using first available screen (ID: {}, Name: {:?}): {}x{}",
+                    id,
+                    info.name.as_deref().unwrap_or("N/A"),
+                    screen_width_px,
+                    screen_height_px
+                );
+                if self.identified_target_wl_output_name.is_none() {
+                    self.identified_target_wl_output_name = Some(*id);
+                }
+            } else {
+                log::warn!(
+                    "No screen with valid dimensions. Falling back to {}x{} for size calculation.",
+                    screen_width_px,
+                    screen_height_px
+                );
+            }
+        }
+        let (layout_w, layout_h) = self.get_key_layout_bounds();
+        let aspect = if layout_h > 0.0 {
+            layout_w / layout_h
+        } else {
+            16.0 / 9.0
+        };
+        let mut target_w = 0;
+        let mut target_h = 0;
+        match self.config.overlay.size_width {
+            Some(SizeDimension::Pixels(px)) => target_w = px,
+            Some(SizeDimension::Ratio(r)) => target_w = (screen_width_px as f32 * r).round() as u32,
+            None => {}
+        }
+        match self.config.overlay.size_height {
+            Some(SizeDimension::Pixels(px)) => target_h = px,
+            Some(SizeDimension::Ratio(r)) => {
+                target_h = (screen_height_px as f32 * r).round() as u32
+            }
+            None => {}
+        }
+        if target_w > 0 && target_h == 0 {
+            target_h = (target_w as f32 / aspect).round() as u32;
+        } else if target_h > 0 && target_w == 0 {
+            target_w = (target_h as f32 * aspect).round() as u32;
+        } else if target_w == 0 && target_h == 0 {
+            target_h = (screen_height_px as f32 * 0.3).round() as u32;
+            target_w = (target_h as f32 * aspect).round() as u32;
+            log::warn!("Overlay size 0x0. Defaulting: {}x{}", target_w, target_h);
+        }
+        if target_w > screen_width_px as u32 && screen_width_px > 0 {
+            let old_w = target_w;
+            target_w = screen_width_px as u32;
+            target_h = (target_w as f32 / aspect).round() as u32;
+            log::info!(
+                "Width {} exceeded screen {}. Adjusted: {}x{}",
+                old_w,
+                screen_width_px,
+                target_w,
+                target_h
+            );
+        }
+        if target_h > screen_height_px as u32 && screen_height_px > 0 {
+            let old_h = target_h;
+            target_h = screen_height_px as u32;
+            target_w = (target_h as f32 * aspect).round() as u32;
+            log::info!(
+                "Height {} exceeded screen {}. Adjusted: {}x{}",
+                old_h,
+                screen_height_px,
+                target_w,
+                target_h
+            );
+        }
+        if target_w == 0 && screen_width_px > 0 {
+            target_w = (screen_width_px as f32 * 0.1).round().max(1.0) as u32;
+        }
+        if target_h == 0 && screen_height_px > 0 {
+            target_h = (screen_height_px as f32 * 0.1).round().max(1.0) as u32;
+        }
+        if target_w == 0 {
+            target_w = 100;
+        }
+        if target_h == 0 {
+            target_h = 50;
+        }
+        log::info!("Setting layer surface size: {}x{}", target_w, target_h);
+        if let Some(ls) = self.layer_surface.as_ref() {
+            ls.set_size(target_w, target_h);
+            self.initial_surface_size_set = true;
+            if let Some(s) = self.surface.as_ref() {
+                s.commit();
+                log::info!("Layer surface size set, surface committed.");
+            } else {
+                log::error!("Cannot commit surface for layer size, surface is None.");
+            }
+            self.needs_redraw = true;
+        } else {
+            log::error!("Cannot set layer surface size, layer_surface is None.");
+        }
+    }
+
+    pub fn get_key_layout_bounds(&self) -> (f32, f32) {
+        if self.config.key.is_empty() {
+            return (0.0, 0.0);
+        }
+        let (mut min_x, mut max_x, mut min_y, mut max_y) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
+        for kc in &self.config.key {
+            min_x = min_x.min(kc.left);
+            max_x = max_x.max(kc.left + kc.width);
+            min_y = min_y.min(kc.top);
+            max_y = max_y.max(kc.top + kc.height);
+        }
+        ((max_x - min_x).max(0.0), (max_y - min_y).max(0.0))
+    }
+
+    pub fn draw(&mut self, qh: &QueueHandle<AppState>) {
+        if self.surface.is_none() || self.shm.is_none() || self.compositor.is_none() {
+            log::error!("Draw: missing Wayland objects.");
+            return;
+        }
+        let surface = self.surface.as_ref().unwrap();
+        let shm = self.shm.as_ref().unwrap();
+        let width = self.configured_width;
+        let height = self.configured_height;
+        let stride = width * 4;
+        let size = (stride * height) as usize;
+        if self.temp_file.is_none()
+            || self.mmap.is_none()
+            || self.mmap.as_ref().is_none_or(|m| m.len() < size)
+        {
+            if let Some(b) = self.buffer.take() {
+                b.destroy();
+            }
+            self.mmap = None;
+            self.temp_file = None;
+            let tf = tempfile::tempfile().expect("SHM tempfile creation failed");
+            tf.set_len(size as u64)
+                .expect("SHM tempfile set_len failed");
+            self.mmap = Some(unsafe { MmapMut::map_mut(&tf).expect("SHM mmap failed") });
+            self.temp_file = Some(tf);
+        }
+        let fd = self.temp_file.as_ref().unwrap().as_raw_fd();
+        let pool = shm.create_pool(fd, size as i32, qh, ());
+        let buffer = pool.create_buffer(0, width, height, stride, wl_shm::Format::Argb8888, qh, ());
+        pool.destroy();
+        let mmap_ptr = self.mmap.as_mut().unwrap().as_mut_ptr();
+        let cairo_surface = match unsafe {
+            cairo::ImageSurface::create_for_data_unsafe(
+                mmap_ptr,
+                cairo::Format::ARgb32,
+                width,
+                height,
+                stride,
+            )
+        } {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("Cairo ImageSurface creation failed: {:?}", e);
+                surface.attach(Some(&buffer), 0, 0);
+                surface.damage_buffer(0, 0, width, height);
+                surface.commit();
+                if let Some(ob) = self.buffer.replace(buffer) {
+                    ob.destroy();
+                }
+                return;
+            }
+        };
+        let ctx = cairo::Context::new(&cairo_surface).expect("Cairo Context creation failed");
+
+        // --- Start of logic moved from draw::render_keyboard_to_context ---
+        let scale: f32;
+        let offset_x: f32;
+        let offset_y: f32;
+        if self.layout_cache_valid
+            && self.configured_width == self.last_draw_width
+            && self.configured_height == self.last_draw_height
+        {
+            scale = self.cached_scale;
+            offset_x = self.cached_offset_x;
+            offset_y = self.cached_offset_y;
+        } else {
+            let (layout_w, layout_h) = self.get_key_layout_bounds(); // Use existing method
+            let padding = if self.config.overlay.size_width.is_some()
+                || self.config.overlay.size_height.is_some()
+            {
+                2.0
+            } else {
+                (width.min(height) as f32 * 0.05).max(5.0)
+            };
+            let draw_w = (width as f32 - 2.0 * padding).max(0.0);
+            let draw_h = (height as f32 - 2.0 * padding).max(0.0);
+            let scale_x = if layout_w > 0.0 {
+                draw_w / layout_w
+            } else {
+                1.0
+            };
+            let scale_y = if layout_h > 0.0 {
+                draw_h / layout_h
+            } else {
+                1.0
+            };
+            scale = scale_x.min(scale_y).max(0.01);
+            let scaled_layout_w = layout_w * scale;
+            let scaled_layout_h = layout_h * scale;
+            let min_coord_x = self
+                .config
+                .key
+                .iter()
+                .map(|k| k.left)
+                .fold(f32::MAX, |a, b| a.min(b)); // Recalc min_coord for offset
+            let min_coord_y = self
+                .config
+                .key
+                .iter()
+                .map(|k| k.top)
+                .fold(f32::MAX, |a, b| a.min(b));
+            offset_x = padding + (draw_w - scaled_layout_w) / 2.0 - (min_coord_x * scale);
+            offset_y = padding + (draw_h - scaled_layout_h) / 2.0 - (min_coord_y * scale);
+            self.cached_scale = scale;
+            self.cached_offset_x = offset_x;
+            self.cached_offset_y = offset_y;
+            self.last_draw_width = width;
+            self.last_draw_height = height;
+            self.layout_cache_valid = true;
+        }
+
+        let font_data: &[u8] = include_bytes!("../default-font/DejaVuSansMono.ttf");
+        let ft_library = FreeTypeLibrary::init().expect("FT init failed");
+        let ft_face = ft_library
+            .new_memory_face(font_data.to_vec(), 0)
+            .expect("FT face load failed");
+        let cairo_font_face =
+            CairoFontFace::create_from_ft(&ft_face).expect("Cairo FT face creation failed");
+
+        let default_fallback_color = (0.1, 0.1, 0.1, 1.0);
+        let key_outline_color = parse_color_string(&self.config.overlay.default_key_outline_color)
+            .unwrap_or(default_fallback_color);
+        let default_key_text_color =
+            parse_color_string(&self.config.overlay.default_key_text_color)
+                .unwrap_or(default_fallback_color);
+        let active_key_bg_color =
+            parse_color_string(&self.config.overlay.active_key_background_color)
+                .unwrap_or((0.6, 0.6, 0.9, 1.0));
+        let active_key_text_color = parse_color_string(&self.config.overlay.active_key_text_color)
+            .unwrap_or(default_key_text_color);
+        let ultimate_inactive_bg_fallback =
+            parse_color_string(&default_key_background_color_string())
+                .unwrap_or((0.3, 0.3, 0.3, 0.5));
+
+        let keys_to_draw: Vec<KeyDisplay> = self
+            .config
+            .key
+            .iter()
+            .map(|kc| {
+                let is_pressed = *self.key_states.get(&kc.keycode).unwrap_or(&false);
+                let bg_color = if is_pressed {
+                    active_key_bg_color
+                } else {
+                    kc.background_color
+                        .as_ref()
+                        .and_then(|s| parse_color_string(s).ok())
+                        .unwrap_or_else(|| {
+                            parse_color_string(&self.config.overlay.default_key_background_color)
+                                .unwrap_or(ultimate_inactive_bg_fallback)
+                        })
+                };
+                let text_color = if is_pressed {
+                    active_key_text_color
+                } else {
+                    default_key_text_color
+                };
+                KeyDisplay {
+                    text: kc.name.clone(),
+                    center_x: (kc.left + kc.width / 2.0) * scale + offset_x,
+                    center_y: (kc.top + kc.height / 2.0) * scale + offset_y,
+                    width: kc.width * scale,
+                    height: kc.height * scale,
+                    corner_radius: kc.corner_radius.unwrap_or(DEFAULT_CORNER_RADIUS_UNSCALED)
+                        * scale,
+                    border_thickness: kc
+                        .border_thickness
+                        .unwrap_or(DEFAULT_BORDER_THICKNESS_UNSCALED)
+                        * scale,
+                    rotation_degrees: kc.rotation_degrees.unwrap_or(DEFAULT_ROTATION_DEGREES),
+                    text_size: kc.text_size.unwrap_or(DEFAULT_TEXT_SIZE_UNSCALED) * scale,
+                    border_color: key_outline_color,
+                    background_color: bg_color,
+                    text_color,
+                }
+            })
+            .collect();
+        // --- End of logic moved from draw::render_keyboard_to_context ---
+
+        draw::paint_all_keys(
+            &ctx,
+            &keys_to_draw,
+            &self.config.overlay.background_color_inactive,
+            &cairo_font_face,
+        );
+
+        cairo_surface.flush();
+        log::debug!("Draw complete.");
+        surface.attach(Some(&buffer), 0, 0);
+        surface.damage_buffer(0, 0, width, height);
+        surface.commit();
+        if let Some(old_buffer) = self.buffer.replace(buffer) {
+            old_buffer.destroy();
+        }
+    }
+}
+
+impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ()> for AppState {
+    fn event(
+        state: &mut Self,
+        ls: &zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
+        event: zwlr_layer_surface_v1::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_layer_surface_v1::Event::Configure {
+                serial,
+                width,
+                height,
+            } => {
+                log::info!("LayerSurface Configure: {}, {}x{}", serial, width, height);
+                if width > 0 {
+                    state.configured_width = width as i32;
+                }
+                if height > 0 {
+                    state.configured_height = height as i32;
+                }
+                ls.ack_configure(serial);
+                state.needs_redraw = true;
+                if state.surface.is_some() {
+                    state.draw(qh);
+                    state.needs_redraw = false;
+                }
+            }
+            zwlr_layer_surface_v1::Event::Closed => {
+                log::info!("LayerSurface Closed.");
+                state.running = false;
+            }
+            _ => {
+                log::trace!("Unhandled zwlr_layer_surface_v1 event: {:?}", event);
+            }
+        }
+    }
+}
+impl Dispatch<xdg_wm_base::XdgWmBase, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        p: &xdg_wm_base::XdgWmBase,
+        e: xdg_wm_base::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_wm_base::Event::Ping { serial } = e {
+            p.pong(serial);
+        }
+    }
+}
+impl Dispatch<xdg_surface::XdgSurface, ()> for AppState {
+    fn event(
+        s: &mut Self,
+        p: &xdg_surface::XdgSurface,
+        e: xdg_surface::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let xdg_surface::Event::Configure { serial, .. } = e {
+            p.ack_configure(serial);
+            if s.surface.is_some() {
+                s.draw(qh);
+                s.needs_redraw = false;
+            }
+        }
+    }
+}
+impl Dispatch<xdg_toplevel::XdgToplevel, ()> for AppState {
+    fn event(
+        s: &mut Self,
+        _: &xdg_toplevel::XdgToplevel,
+        e: xdg_toplevel::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match e {
+            xdg_toplevel::Event::Configure { width, height, .. } => {
+                if width > 0 {
+                    s.configured_width = width;
+                }
+                if height > 0 {
+                    s.configured_height = height;
+                }
+            }
+            xdg_toplevel::Event::Close => s.running = false,
+            _ => {}
+        }
+    }
+}
+impl Dispatch<wl_compositor::WlCompositor, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        _: &wl_compositor::WlCompositor,
+        _: wl_compositor::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<wl_surface::WlSurface, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        _: &wl_surface::WlSurface,
+        _: wl_surface::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<wl_shm::WlShm, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        _: &wl_shm::WlShm,
+        _: wl_shm::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<wl_registry::WlRegistry, ()> for AppState {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            match interface.as_str() {
+                "wl_compositor" => {
+                    state.compositor = Some(registry.bind(name, 5.min(version), qh, ()));
+                }
+                "wl_shm" => {
+                    state.shm = Some(registry.bind(name, 1.min(version), qh, ()));
+                }
+                "xdg_wm_base" => {
+                    state.xdg_wm_base = Some(registry.bind(name, 3.min(version), qh, ()));
+                }
+                "zwlr_layer_shell_v1" => {
+                    state.layer_shell = Some(registry.bind(name, 4.min(version), qh, ()));
+                    log::info!("Bound zwlr_layer_shell_v1 v{}", 4.min(version));
+                }
+                "zxdg_output_manager_v1" => {
+                    state.xdg_output_manager = Some(registry.bind(name, 3.min(version), qh, ()));
+                    log::info!("Bound zxdg_output_manager_v1 v{}", 3.min(version));
+                }
+                "wl_output" => {
+                    let out =
+                        registry.bind::<wl_output::WlOutput, _, _>(name, 4.min(version), qh, ());
+                    let xdg_out = state
+                        .xdg_output_manager
+                        .as_ref()
+                        .map(|m| m.get_xdg_output(&out, qh, ()));
+                    state
+                        .outputs
+                        .push((name, out, xdg_out, OutputInfo::default()));
+                    log::info!("Bound wl_output (id {}) v{}", name, 4.min(version));
+                }
+                _ => {}
+            }
+        } else if let wl_registry::Event::GlobalRemove { name } = event {
+            state.outputs.retain(|(id, _, _, _)| *id != name);
+            if state.identified_target_wl_output_name == Some(name) {
+                state.identified_target_wl_output_name = None;
+            }
+        }
+    }
+}
+impl Dispatch<wl_output::WlOutput, ()> for AppState {
+    fn event(
+        _s: &mut Self,
+        o: &wl_output::WlOutput,
+        e: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_output::Event::Name { name } = e {
+            log::debug!("wl_output {:?} Name: {}", o.id(), name);
+        }
+    }
+}
+impl Dispatch<zxdg_output_manager_v1::ZxdgOutputManagerV1, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        _: &zxdg_output_manager_v1::ZxdgOutputManagerV1,
+        e: zxdg_output_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        log::trace!("zxdg_output_manager_v1 event: {:?}", e);
+    }
+}
+impl Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for AppState {
+    fn event(
+        state: &mut Self,
+        xdg_o: &zxdg_output_v1::ZxdgOutputV1,
+        e: zxdg_output_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let opt = state
+            .outputs
+            .iter_mut()
+            .find(|(_, _, xo, _)| xo.as_ref() == Some(xdg_o));
+        if let Some((id, _, _, info)) = opt {
+            match e {
+                zxdg_output_v1::Event::LogicalSize { width, height } => {
+                    info.logical_width = width;
+                    info.logical_height = height;
+                    if !state.initial_surface_size_set
+                        && (state.identified_target_wl_output_name.is_none()
+                            || state.identified_target_wl_output_name == Some(*id))
+                        && info.logical_width > 0
+                        && info.logical_height > 0
+                    {
+                        state.attempt_configure_layer_surface_size();
+                    }
+                }
+                zxdg_output_v1::Event::Done => {
+                    if !state.initial_surface_size_set
+                        && (state.identified_target_wl_output_name.is_none()
+                            || state.identified_target_wl_output_name == Some(*id))
+                        && info.logical_width > 0
+                        && info.logical_height > 0
+                    {
+                        state.attempt_configure_layer_surface_size();
+                    }
+                }
+                zxdg_output_v1::Event::Name { name } => {
+                    info.name = Some(name);
+                }
+                zxdg_output_v1::Event::Description { description } => {
+                    info.description = Some(description);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+impl Dispatch<wl_shm_pool::WlShmPool, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        _: &wl_shm_pool::WlShmPool,
+        _: wl_shm_pool::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+impl Dispatch<wl_buffer::WlBuffer, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        b: &wl_buffer::WlBuffer,
+        e: wl_buffer::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_buffer::Event::Release = e {
+            log::debug!("Buffer {:?} released", b.id());
+        }
+    }
+}
+impl Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, ()> for AppState {
+    fn event(
+        _: &mut Self,
+        _: &zwlr_layer_shell_v1::ZwlrLayerShellV1,
+        e: zwlr_layer_shell_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        log::trace!("zwlr_layer_shell_v1 event: {:?}", e);
+    }
+}
+
+pub fn handle_wayland_events(
+    conn: &Connection,
+    event_queue: &mut EventQueue<AppState>,
+    app_state: &mut AppState,
+) -> Result<(), ()> {
+    match conn.prepare_read() {
+        Ok(guard) => match guard.read() {
+            Ok(_) => {
+                if event_queue.dispatch_pending(app_state).is_err() {
+                    app_state.running = false;
+                    return Err(());
+                }
+            }
+            Err(wayland_client::backend::WaylandError::Io(io_err))
+                if io_err.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(_) => {
+                app_state.running = false;
+                return Err(());
+            }
+        },
+        Err(_) => {
+            app_state.running = false;
+            return Err(());
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION


This commit splits the main application logic from `src/main.rs` into
several distinct modules:

- `src/config.rs`: Handles configuration loading, parsing, validation,
  and related data structures (AppConfig, KeyConfig, OverlayConfig, etc.).
- `src/event.rs`: Manages input event handling using libinput, including
  the LibinputInterface implementation and the main input event loop logic.
- `src/draw.rs`: Contains logic for rendering the on-screen display,
  including preparing key display data and using Cairo for drawing.
- `src/wayland.rs`: Encapsulates Wayland-specific interactions, including
  the main `AppState` struct, Wayland object dispatchers, buffer management,
  and Wayland event handling.

The `src/main.rs` file now serves as the primary entry point,
orchestrating the setup and the main event loop by calling functions
from the new modules.

Key changes during refactoring:
- Moved relevant structs, enums, functions, and constants to their
  respective modules.
- Refactored `AppState` (now primarily in `wayland.rs`) and its `draw`
  method to better separate concerns and resolve a borrow-checking issue (E0502).
  The `draw` method in `AppState` now handles layout calculations and cache
  updates, then calls a function in the `draw` module with immutable data
  for the actual rendering.
- Ensured all necessary system dependencies were installed using
  `./install-dev-deps.sh`.
- Addressed compiler warnings related to unused imports and variables.
- Formatted code with `cargo fmt`.
- Applied `cargo clippy --fix` to resolve linting issues.

All unit and integration tests pass after these changes.