### PR TITLE
Refactor: Code cleanup and simplification

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 use serde_value::Value as SerdeValue;
 use std::collections::HashMap;
 use std::fs;
-// use std::process; // This was unused
 
 use crate::keycodes;
 
@@ -423,7 +422,6 @@ pub fn simulate_text_layout(
         let ellipsis_width_px = get_ft_text_width(ellipsis, current_font_size_pts, ft_face)?;
 
         while text_width_px > max_text_width_px && !current_text.is_empty() {
-            // let initial_len_before_pop = current_text.chars().count(); // Unused
             current_text.pop();
             truncated_chars = original_text.chars().count() - current_text.chars().count();
 
@@ -459,11 +457,10 @@ pub fn simulate_text_layout(
                 temp_ellipsis.pop();
             }
             current_text = temp_ellipsis;
-            if current_text.starts_with(ellipsis.chars().next().unwrap_or_default())
-                && current_text.len() < ellipsis.len()
+            if (current_text.starts_with(ellipsis.chars().next().unwrap_or_default())
+                && current_text.len() < ellipsis.len())
+                || current_text.is_empty()
             {
-                truncated_chars = original_text.chars().count();
-            } else if current_text.is_empty() {
                 truncated_chars = original_text.chars().count();
             }
         }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,16 +1,8 @@
 // Drawing the keyboard
 
 use cairo::{Context, FontFace as CairoFontFace};
-// FreeTypeLibrary is not directly used here if font face is passed in.
-// use freetype::{Library as FreeTypeLibrary};
 
 use crate::config::parse_color_string; // Only parse_color_string is needed for background
-                                       // KeyConfig was unused here as KeyDisplay is now fully populated by AppState::draw
-                                       // use crate::config::{KeyConfig, parse_color_string, default_key_background_color_string,
-                                       //                     DEFAULT_CORNER_RADIUS_UNSCALED, DEFAULT_BORDER_THICKNESS_UNSCALED,
-                                       //                     DEFAULT_TEXT_SIZE_UNSCALED, DEFAULT_ROTATION_DEGREES};
-                                       // use wayland_client::QueueHandle; // Not directly used here
-                                       // use wayland_client::protocol::wl_shm; // Not directly used here
 
 // Struct to hold key properties for drawing (calculated from KeyConfig and AppState)
 // This struct is prepared by AppState::draw and passed to paint_all_keys

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,7 +5,7 @@ use input::event::Event as LibinputEvent;
 use libc::{O_NONBLOCK, O_RDWR};
 use std::fs::OpenOptions;
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::OwnedFd; // AsRawFd was unused
+use std::os::unix::io::OwnedFd;
 use std::path::Path;
 
 // Assuming AppState is defined in wayland.rs and passed here
@@ -37,8 +37,6 @@ pub fn handle_libinput_events(app_state: &mut AppState) {
     if let Some(ref mut context) = app_state.input_context {
         if context.dispatch().is_err() {
             log::error!("Libinput dispatch error");
-            // Optionally, you might want to handle this error more robustly,
-            // e.g., by trying to re-initialize libinput or by stopping input handling.
         }
         for event in context.by_ref() {
             if let LibinputEvent::Keyboard(KeyboardEvent::Key(key_event)) = event {

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -138,7 +138,6 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         "pagedown" | "pgdn" => Ok(109),
         "insert" | "ins" => Ok(110),
         "delete" | "del" => Ok(111),
-        // "macro" => Ok(112), // Generic, probably not for direct use by name
         "mute" => Ok(113),
         "volumedown" => Ok(114),
         "volumeup" => Ok(115),
@@ -146,11 +145,9 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
         "kpequal" | "keypadequal" => Ok(117),
         "kpplusminus" | "keypadplusminus" => Ok(118),
         "pause" | "pausebreak" => Ok(119),
-        // "scale" => Ok(120), // AL Compiz Scale (Expose) - less common by name
         "kpcomma" | "keypadcomma" => Ok(121), // Often on Brazilian/some European layouts
-        // "hangeul" | "hanguel" => Ok(122), // Korean Hangeul
-        "hanja" => Ok(123), // Korean Hanja
-        "yen" => Ok(124),   // Japanese Yen (sometimes different from Ro)
+        "hanja" => Ok(123),                   // Korean Hanja
+        "yen" => Ok(124),                     // Japanese Yen (sometimes different from Ro)
         "leftmeta" | "lmeta" | "leftwindows" | "lwin" | "leftsuper" | "lsuper" => Ok(125),
         "rightmeta" | "rmeta" | "rightwindows" | "rwin" | "rightsuper" | "rsuper" => Ok(126),
         "compose" => Ok(127), // Compose key
@@ -223,8 +220,6 @@ pub fn get_keycode_from_string(key_name_str: &str) -> Result<u32, String> {
 
         "fn" => Ok(0x1d0),    // 464
         "fnesc" => Ok(0x1d1), // 465
-        // Not adding all KEY_FN_F<N> as they are less common to specify by name
-        // and "f<N>" should cover it.
         _ => Err(format!("Unknown key name: '{}'", key_name_str)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ mod wayland;
 // External Crate Imports
 use clap::Parser;
 use freetype::Library as FreeTypeLibrary; // Used for --check
- // Used for input::Libinput::new_with_udev by event.rs, but main needs it to create the context
 
 // Using items from the new modules
 use config::{
@@ -26,7 +25,6 @@ use config::{
     validate_config,
     AppConfig,
     DEFAULT_TEXT_SIZE_UNSCALED,
-    // parse_color_string as config_parse_color_string, // aliased, but print_overlay_config_for_check uses config::parse_color_string
 };
 use event::MyLibinputInterface;
 // handle_libinput_events is called via event::handle_libinput_events
@@ -34,11 +32,8 @@ use event::MyLibinputInterface;
 use wayland::AppState;
 
 // Protocol imports for main function logic (surface creation, layer shell)
-use wayland_client::protocol::wl_output; // For selected_wl_output_proxy
-                                         // The following are not directly used in main after refactor, they are used within wayland.rs
-                                         // use wayland_client::protocol::{wl_surface, wl_compositor, wl_shm, wl_registry};
-                                         // use wayland_protocols::xdg::shell::client::{xdg_wm_base, xdg_surface, xdg_toplevel};
 use wayland_client::backend::WaylandError;
+use wayland_client::protocol::wl_output; // For selected_wl_output_proxy
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 
 /// Command-line arguments
@@ -61,12 +56,16 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
 
-    if let Some(e) = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .try_init()
-        .err() { eprintln!(
-                "Failed to initialize logger: {}. Continuing without detailed logging for --check.",
-                e
-            ) }
+    if let Some(e) =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+            .try_init()
+            .err()
+    {
+        eprintln!(
+            "Failed to initialize logger: {}. Continuing without detailed logging for --check.",
+            e
+        )
+    }
 
     let app_config: AppConfig = match load_and_process_config(&cli.config_path) {
         Ok(config) => config,
@@ -480,7 +479,9 @@ fn main() {
         } else if ret == 0 {
             // Timeout
         } else {
-            if (fds[WAYLAND_FD_IDX].revents & libc::POLLIN) != 0 && wayland::handle_wayland_events(&conn, &mut event_queue, &mut app_state).is_err() {
+            if (fds[WAYLAND_FD_IDX].revents & libc::POLLIN) != 0
+                && wayland::handle_wayland_events(&conn, &mut event_queue, &mut app_state).is_err()
+            {
                 break;
             }
             if (fds[WAYLAND_FD_IDX].revents & (libc::POLLERR | libc::POLLHUP)) != 0 {

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -1,5 +1,5 @@
 // Wayland interaction
- // Added for input::Libinput
+// Added for input::Libinput
 use wayland_client::protocol::{
     wl_buffer, wl_compositor, wl_output, wl_registry, wl_shm, wl_shm_pool, wl_surface,
 };

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -45,13 +45,11 @@ mod tests {
         );
 
         let stderr_thread = thread::spawn(move || {
-            for line_result in stderr_reader.lines() {
-                if let Ok(line) = line_result {
-                    println!("[SWAY STDERR] {}", line); // Print sway's stderr for debugging
-                    let mut stderr_lock = sway_stderr_clone.lock().unwrap();
-                    stderr_lock.push_str(&line);
-                    stderr_lock.push('\n');
-                }
+            for line in stderr_reader.lines().map_while(Result::ok) {
+                println!("[SWAY STDERR] {}", line); // Print sway's stderr for debugging
+                let mut stderr_lock = sway_stderr_clone.lock().unwrap();
+                stderr_lock.push_str(&line);
+                stderr_lock.push('\n');
             }
         });
 
@@ -63,10 +61,8 @@ mod tests {
                 .expect("Failed to get sway stdout"),
         );
         let stdout_thread = thread::spawn(move || {
-            for line_result in stdout_reader.lines() {
-                if let Ok(line) = line_result {
-                    println!("[SWAY STDOUT] {}", line);
-                }
+            for line in stdout_reader.lines().map_while(Result::ok) {
+                println!("[SWAY STDOUT] {}", line);
             }
         });
 
@@ -213,13 +209,11 @@ mod tests {
         );
 
         let stderr_thread = thread::spawn(move || {
-            for line_result in stderr_reader.lines() {
-                if let Ok(line) = line_result {
-                    println!("[SWAY_OVERLAY STDERR] {}", line); // Print sway's stderr for debugging
-                    let mut stderr_lock = sway_stderr_clone.lock().unwrap();
-                    stderr_lock.push_str(&line);
-                    stderr_lock.push('\n');
-                }
+            for line in stderr_reader.lines().map_while(Result::ok) {
+                println!("[SWAY_OVERLAY STDERR] {}", line); // Print sway's stderr for debugging
+                let mut stderr_lock = sway_stderr_clone.lock().unwrap();
+                stderr_lock.push_str(&line);
+                stderr_lock.push('\n');
             }
         });
 
@@ -231,10 +225,8 @@ mod tests {
                 .expect("Failed to get sway stdout"),
         );
         let stdout_thread = thread::spawn(move || {
-            for line_result in stdout_reader.lines() {
-                if let Ok(line) = line_result {
-                    println!("[SWAY_OVERLAY STDOUT] {}", line);
-                }
+            for line in stdout_reader.lines().map_while(Result::ok) {
+                println!("[SWAY_OVERLAY STDOUT] {}", line);
             }
         });
 


### PR DESCRIPTION


- Removed commented-out code across multiple files.
- Removed unused imports and variables.
- Simplified some conditional logic based on clippy suggestions.
- Addressed clippy warnings related to iterator usage in tests.