### PR TITLE
Refactor: Replace serde_value with KeycodeRepr using untagged enum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,14 @@ cargo test
 - Any comments containing commentary about a change should be removed before committing.
 - If code is commented out while making changes, remove the commented out code before committing.
 
+**Linting with Clippy:**
+
+Run `cargo clippy` to check for lints and manually fix any reported issues.
+
+```bash
+cargo clippy
+```
+
 
 ## Visual Inspection with `take_screenshot.sh`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,15 +430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,15 +440,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "pkg-config"
@@ -568,16 +550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -804,7 +776,6 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde-value",
  "tempfile",
  "toml",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ input = "0.9.1"
 libc = "0.2"
 toml = "0.8"
 serde = { version = "1.0", features = ["derive"] }
-serde-value = "0.7" # For flexible TOML value parsing
 regex = "1.10"      # For parsing input-event-codes.h
 once_cell = "1.19"  # For static LAZY KEYCODE_MAP
 clap = { version = "4.4", features = ["derive"] }

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -1,6 +1,15 @@
 // Based on Linux input-event-codes.h
 // Fetched from: https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/input-event-codes.h
 
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum KeycodeRepr {
+    Number(u32),
+    Text(String),
+}
+
 /// Resolves a key name string (e.g., "leftshift", "a", "KP_Enter") to its Linux keycode.
 ///
 /// ## Normalization Rules:

--- a/src/poll_fds.rs
+++ b/src/poll_fds.rs
@@ -2,7 +2,6 @@
 // polling of file descriptors using the `poll` syscall.
 // It supports Wayland and libinput file descriptors.
 
-use libc;
 use std::os::unix::io::AsRawFd;
 use wayland_client::Connection;
 use input::Libinput;


### PR DESCRIPTION
This commit replaces the `serde_value::Value` type used for keycode deserialization with a new `KeycodeRepr` enum. The `KeycodeRepr` enum uses serde's `#[serde(untagged)]` attribute to allow keycodes to be specified as either numbers (e.g., `keycode = 30`) or strings (e.g., `keycode = "a"`) in the `keys.toml` configuration file.

This change simplifies the keycode parsing logic and removes the `serde_value` dependency.

Additionally, `AGENTS.md` has been updated with instructions to run `cargo clippy` and manually fix lints.